### PR TITLE
Ensure all contract properties are initialized before end of initializer

### DIFF
--- a/Sources/AST/AST.swift
+++ b/Sources/AST/AST.swift
@@ -158,7 +158,7 @@ public struct FunctionDeclaration: SourceEntity {
 
   /// The raw type of the function's return type.
   public var rawType: Type.RawType {
-    return resultType?.rawType ?? .builtInType(.void)
+    return resultType?.rawType ?? .basicType(.void)
   }
 
   public var sourceLocation: SourceLocation {
@@ -307,7 +307,7 @@ public struct Parameter: SourceEntity {
 
   /// Whether the parameter is both `implicit` and has a currency type.
   public var isPayableValueParameter: Bool {
-    if isImplicit, case .builtInType(let type) = type.rawType, type.isCurrencyType {
+    if isImplicit, case .basicType(let type) = type.rawType, type.isCurrencyType {
       return true
     }
     return false
@@ -367,7 +367,7 @@ public struct Identifier: Hashable, SourceEntity {
 public struct Type: SourceEntity {
   /// A Flint raw type, without a source location.
   public indirect enum RawType: Equatable {
-    case builtInType(BuiltInType)
+    case basicType(BasicType)
     case arrayType(RawType)
     case fixedSizeArrayType(RawType, size: Int)
     case dictionaryType(key: RawType, value: RawType)
@@ -380,7 +380,7 @@ public struct Type: SourceEntity {
       switch self {
       case .fixedSizeArrayType(let rawType, size: let size): return "\(rawType.name)[\(size)]"
       case .arrayType(let rawType): return "[\(rawType.name)]"
-      case .builtInType(let builtInType): return "\(builtInType.rawValue)"
+      case .basicType(let builtInType): return "\(builtInType.rawValue)"
       case .dictionaryType(let keyType, let valueType): return "[\(keyType.name): \(valueType.name)]"
       case .userDefinedType(let identifier): return identifier
       case .inoutType(let rawType): return "&\(rawType)"
@@ -389,18 +389,24 @@ public struct Type: SourceEntity {
       }
     }
 
-    public var isBasicType: Bool {
-      if case .builtInType(_) = self { return true }
-      return false
+    public var isBuiltInType: Bool {
+      switch self {
+      case .basicType(_), .any, .errorType: return true
+      case .arrayType(let element): return element.isBuiltInType
+      case .fixedSizeArrayType(let element, _): return element.isBuiltInType
+      case .dictionaryType(let key, let value): return key.isBuiltInType && value.isBuiltInType
+      case .inoutType(let element): return element.isBuiltInType
+      case .userDefinedType(_): return false
+      }
     }
 
     public var isEventType: Bool {
-      return self == .builtInType(.event)
+      return self == .basicType(.event)
     }
 
     /// Whether the type is a dynamic type.
     public var isDynamicType: Bool {
-      if case .builtInType(_) = self {
+      if case .basicType(_) = self {
         return false
       }
 
@@ -427,7 +433,7 @@ public struct Type: SourceEntity {
     }
   }
 
-  public enum BuiltInType: String {
+  public enum BasicType: String {
     case address = "Address"
     case int = "Int"
     case string = "String"
@@ -463,8 +469,8 @@ public struct Type: SourceEntity {
 
   public init(identifier: Identifier, genericArguments: [Type] = []) {
     let name = identifier.name
-    if let builtInType = BuiltInType(rawValue: name) {
-      rawType = .builtInType(builtInType)
+    if let builtInType = BasicType(rawValue: name) {
+      rawType = .basicType(builtInType)
     } else {
       rawType = .userDefinedType(name)
     }

--- a/Sources/AST/AST.swift
+++ b/Sources/AST/AST.swift
@@ -262,7 +262,7 @@ public struct InitializerDeclaration: SourceEntity {
     self.parameters = parameters
     self.closeBracketToken = closeBracketToken
     self.body = body
-    self.closeBraceToken = closeBracketToken
+    self.closeBraceToken = closeBraceToken
   }
 }
 

--- a/Sources/AST/ASTDumper.swift
+++ b/Sources/AST/ASTDumper.swift
@@ -231,7 +231,7 @@ public class ASTDumper {
         self.dump(keyType)
         self.dump(valueType)
       }
-    case .builtInType(let builtInType):
+    case .basicType(let builtInType):
       writeNode("BuiltInType") {
         self.dump(builtInType)
       }
@@ -248,7 +248,7 @@ public class ASTDumper {
     }
   }
 
-  func dump(_ builtInType: Type.BuiltInType) {
+  func dump(_ builtInType: Type.BasicType) {
     writeLine("built-in type \(builtInType.rawValue)")
   }
 

--- a/Sources/AST/ASTPassContext.swift
+++ b/Sources/AST/ASTPassContext.swift
@@ -69,10 +69,16 @@ extension ASTPassContext {
     set { self[StructDeclarationContextEntry.self] = newValue }
   }
 
-  /// Contextual information used when visiting statements in a function, such as if it is mutating or note.
+  /// Contextual information used when visiting statements in a function, such as if the function is mutating or note.
   public var functionDeclarationContext: FunctionDeclarationContext? {
     get { return self[FunctionDeclarationContextEntry.self] }
     set { self[FunctionDeclarationContextEntry.self] = newValue }
+  }
+
+  /// Contextual information used when visiting statements in an initializer.
+  public var initializerDeclarationContext: InitializerDeclarationContext? {
+    get { return self[InitializerDeclarationContextEntry.self] }
+    set { self[InitializerDeclarationContextEntry.self] = newValue }
   }
 
   /// Contextual information used when visiting a scope, such as the local variables which are accessible in that
@@ -118,6 +124,10 @@ private struct StructDeclarationContextEntry: PassContextEntry {
 
 private struct FunctionDeclarationContextEntry: PassContextEntry {
   typealias Value = FunctionDeclarationContext
+}
+
+private struct InitializerDeclarationContextEntry: PassContextEntry {
+  typealias Value = InitializerDeclarationContext
 }
 
 private struct ScopeContextContextEntry: PassContextEntry {

--- a/Sources/AST/ASTPassContext.swift
+++ b/Sources/AST/ASTPassContext.swift
@@ -55,6 +55,12 @@ extension ASTPassContext {
     set { self[AsLValueContextEntry.self] = newValue }
   }
 
+  /// Contextual information used when visiting the state properties declared in a contract declaration.
+  public var contractStateDeclarationContext: ContractStateDeclarationContext? {
+    get { return self[ContractStateDeclarationContextEntry.self] }
+    set { self[ContractStateDeclarationContextEntry.self] = newValue }
+  }
+
   /// Contextual information used when visiting functions in a contract behavior declaration, such as the name of the
   /// contract the functions are declared for, and the caller capability associated with them.
   public var contractBehaviorDeclarationContext: ContractBehaviorDeclarationContext? {
@@ -112,6 +118,10 @@ private struct EnvironmentContextEntry: PassContextEntry {
 
 private struct AsLValueContextEntry: PassContextEntry {
   typealias Value = Bool
+}
+
+private struct ContractStateDeclarationContextEntry: PassContextEntry {
+  typealias Value = ContractStateDeclarationContext
 }
 
 private struct ContractBehaviorDeclarationContextEntry: PassContextEntry {

--- a/Sources/AST/ASTVisitor.swift
+++ b/Sources/AST/ASTVisitor.swift
@@ -57,9 +57,13 @@ public struct ASTVisitor<Pass: ASTPass> {
 
     processResult.element.identifier = processResult.combining(visit(processResult.element.identifier, passContext: processResult.passContext))
 
+    processResult.passContext.contractStateDeclarationContext = ContractStateDeclarationContext(contractIdentifier: contractDeclaration.identifier)
+
     processResult.element.variableDeclarations = processResult.element.variableDeclarations.map { variableDeclaration in
       return processResult.combining(visit(variableDeclaration, passContext: processResult.passContext))
     }
+
+    processResult.passContext.contractStateDeclarationContext = nil
 
     let postProcessResult = pass.postProcess(contractDeclaration: processResult.element, passContext: processResult.passContext)
     return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
@@ -70,7 +74,7 @@ public struct ASTVisitor<Pass: ASTPass> {
 
     var localVariables = [VariableDeclaration]()
     if let capabilityBinding = contractBehaviorDeclaration.capabilityBinding {
-      localVariables.append(VariableDeclaration(declarationToken: nil, identifier: capabilityBinding, type: Type(inferredType: .builtInType(.address), identifier: capabilityBinding)))
+      localVariables.append(VariableDeclaration(declarationToken: nil, identifier: capabilityBinding, type: Type(inferredType: .basicType(.address), identifier: capabilityBinding)))
     }
 
     let scopeContext = ScopeContext(localVariables: localVariables)

--- a/Sources/AST/ASTVisitor.swift
+++ b/Sources/AST/ASTVisitor.swift
@@ -213,15 +213,17 @@ public struct ASTVisitor<Pass: ASTPass> {
       return processResult.combining(visit(parameter, passContext: processResult.passContext))
     }
 
-    let functionDeclaration = initializerDeclaration.asFunctionDeclaration
+    let initializerDeclarationContext = InitializerDeclarationContext(declaration: initializerDeclaration)
+    processResult.passContext.initializerDeclarationContext = initializerDeclarationContext
 
+    let functionDeclaration = initializerDeclaration.asFunctionDeclaration
     processResult.passContext.scopeContext!.localVariables.append(contentsOf: functionDeclaration.parametersAsVariableDeclarations)
 
     processResult.element.body = processResult.element.body.map { statement in
       return processResult.combining(visit(statement, passContext: processResult.passContext))
     }
 
-    processResult.passContext.functionDeclarationContext = nil
+    processResult.passContext.initializerDeclarationContext = nil
 
     let postProcessResult = pass.postProcess(initializerDeclaration: processResult.element, passContext: processResult.passContext)
     return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)

--- a/Sources/AST/ASTVisitorContext.swift
+++ b/Sources/AST/ASTVisitorContext.swift
@@ -27,7 +27,7 @@ public struct StructDeclarationContext {
   }
 }
 
-/// Contextual information used when visiting statements in a function, such as if it is mutating or not.
+/// Contextual information used when visiting statements in a function, such as if the function is mutating or not.
 public struct FunctionDeclarationContext {
   public var declaration: FunctionDeclaration
 
@@ -37,6 +37,15 @@ public struct FunctionDeclarationContext {
 
   public var isMutating: Bool {
     return declaration.isMutating
+  }
+}
+
+/// Contextual information used when visiting statements in an initializer.
+public struct InitializerDeclarationContext {
+  public var declaration: InitializerDeclaration
+
+  public init(declaration: InitializerDeclaration) {
+    self.declaration = declaration
   }
 }
 

--- a/Sources/AST/ASTVisitorContext.swift
+++ b/Sources/AST/ASTVisitorContext.swift
@@ -5,6 +5,11 @@
 //  Created by Franklin Schrans on 1/11/18.
 //
 
+/// Contextual information used when visiting the state properties declared in a contract declaration.
+public struct ContractStateDeclarationContext {
+  public var contractIdentifier: Identifier
+}
+
 /// Contextual information used when visiting functions in a contract behavior declaration, such as the name of the
 /// contract the functions are declared for, and the caller capability associated with them.
 public struct ContractBehaviorDeclarationContext {

--- a/Sources/AST/Environment.swift
+++ b/Sources/AST/Environment.swift
@@ -116,9 +116,9 @@ public struct Environment {
   func declaredCallerCapabilities(enclosingType: RawTypeIdentifier) -> [String] {
     return types[enclosingType]!.properties.compactMap { key, value in
       switch value.rawType {
-      case .builtInType(.address): return key
-      case .fixedSizeArrayType(.builtInType(.address), _): return key
-      case .arrayType(.builtInType(.address)): return key
+      case .basicType(.address): return key
+      case .fixedSizeArrayType(.basicType(.address), _): return key
+      case .arrayType(.basicType(.address)): return key
       default: return nil
       }
     }
@@ -145,13 +145,13 @@ public struct Environment {
     return matchingFunction.resultType
   }
 
-  /// The type of a literal token.
+  /// The types a literal token can be.
   public func type(ofLiteralToken literalToken: Token) -> Type.RawType {
     guard case .literal(let literal) = literalToken.kind else { fatalError() }
     switch literal {
-    case .boolean(_): return .builtInType(.bool)
-    case .decimal(.integer(_)): return .builtInType(.int)
-    case .string(_): return .builtInType(.string)
+    case .boolean(_): return .basicType(.bool)
+    case .decimal(.integer(_)): return .basicType(.int)
+    case .string(_): return .basicType(.string)
     default: fatalError()
     }
   }
@@ -223,7 +223,7 @@ public struct Environment {
       return .inoutType(type(of: inoutExpression.expression, enclosingType: enclosingType, callerCapabilities: callerCapabilities, scopeContext: scopeContext))
     case .binaryExpression(let binaryExpression):
       if binaryExpression.opToken.isBooleanOperator {
-        return .builtInType(.bool)
+        return .basicType(.bool)
       }
       return type(of: binaryExpression.rhs, enclosingType: enclosingType, callerCapabilities: callerCapabilities, scopeContext: scopeContext)
 
@@ -333,8 +333,8 @@ public struct Environment {
   /// The memory size of a type, in terms of number of memory slots it occupies.
   public func size(of type: Type.RawType) -> Int {
     switch type {
-    case .builtInType(.event): return 0 // Events do not use memory.
-    case .builtInType(_): return 1
+    case .basicType(.event): return 0 // Events do not use memory.
+    case .basicType(_): return 1
     case .fixedSizeArrayType(let rawType, let elementCount): return size(of: rawType) * elementCount
     case .arrayType(_): return 1
     case .dictionaryType(_, _): return 1

--- a/Sources/IRGen/Function/IULIAFunction.swift
+++ b/Sources/IRGen/Function/IULIAFunction.swift
@@ -52,7 +52,7 @@ struct IULIAFunction {
   var scopeContext: ScopeContext {
     var localVariables = functionDeclaration.parametersAsVariableDeclarations
     if let capabilityBinding = capabilityBinding {
-      localVariables.append(VariableDeclaration(declarationToken: nil, identifier: capabilityBinding, type: Type(inferredType: .builtInType(.address), identifier: capabilityBinding)))
+      localVariables.append(VariableDeclaration(declarationToken: nil, identifier: capabilityBinding, type: Type(inferredType: .basicType(.address), identifier: capabilityBinding)))
     }
     return ScopeContext(localVariables: localVariables)
   }
@@ -103,7 +103,7 @@ struct IULIAFunctionBody {
   var scopeContext: ScopeContext {
     var localVariables = functionDeclaration.parametersAsVariableDeclarations
     if let capabilityBinding = capabilityBinding {
-      localVariables.append(VariableDeclaration(declarationToken: nil, identifier: capabilityBinding, type: Type(inferredType: .builtInType(.address), identifier: capabilityBinding)))
+      localVariables.append(VariableDeclaration(declarationToken: nil, identifier: capabilityBinding, type: Type(inferredType: .basicType(.address), identifier: capabilityBinding)))
     }
     return ScopeContext(localVariables: localVariables)
   }

--- a/Sources/IRGen/Function/IULIAInitializer.swift
+++ b/Sources/IRGen/Function/IULIAInitializer.swift
@@ -36,7 +36,7 @@ struct IULIAInitializer {
   var scopeContext: ScopeContext {
     var localVariables = initializerDeclaration.parametersAsVariableDeclarations
     if let capabilityBinding = capabilityBinding {
-      localVariables.append(VariableDeclaration(declarationToken: nil, identifier: capabilityBinding, type: Type(inferredType: .builtInType(.address), identifier: capabilityBinding)))
+      localVariables.append(VariableDeclaration(declarationToken: nil, identifier: capabilityBinding, type: Type(inferredType: .basicType(.address), identifier: capabilityBinding)))
     }
     return ScopeContext(localVariables: localVariables)
   }

--- a/Sources/IRGen/IULIACanonicalType.swift
+++ b/Sources/IRGen/IULIACanonicalType.swift
@@ -15,7 +15,7 @@ enum CanonicalType: String {
 
   init?(from rawType: Type.RawType) {
     switch rawType {
-    case .builtInType(let builtInType):
+    case .basicType(let builtInType):
       switch builtInType {
       case .address: self = .address
       case .int, .bool, .wei: self = .uint256

--- a/Sources/Parser/Parser.swift
+++ b/Sources/Parser/Parser.swift
@@ -339,16 +339,16 @@ extension Parser {
     let contractToken = try consume(.contract)
     let identifier = try parseIdentifier()
     try consume(.punctuation(.openBrace))
-    let variableDeclarations = try parseVariableDeclarations(asTypeProperties: true)
+    let variableDeclarations = try parseVariableDeclarations(enclosingType: identifier.name)
     try consume(.punctuation(.closeBrace))
 
     return ContractDeclaration(contractToken: contractToken, identifier: identifier, variableDeclarations: variableDeclarations)
   }
   
-  func parseVariableDeclarations(asTypeProperties: Bool = false) throws -> [VariableDeclaration] {
+  func parseVariableDeclarations(enclosingType: RawTypeIdentifier) throws -> [VariableDeclaration] {
     var variableDeclarations = [VariableDeclaration]()
     
-    while let variableDeclaration = attempt(try parseVariableDeclaration(asTypeProperty: asTypeProperties)) {
+    while let variableDeclaration = attempt(try parseVariableDeclaration(enclosingType: enclosingType)) {
       variableDeclarations.append(variableDeclaration)
     }
     
@@ -360,11 +360,10 @@ extension Parser {
   /// `VariableDeclaration` struct, where an assignment to a local variable will be represented as a `BinaryExpression`
   /// with an `=` operator.
   ///
-  /// - Parameter asTypeProperty: Whether the variable declaration should be parsed as the declaration of a
-  ///                             type property.
+  /// - Parameter enclosingType: The name of the type in which the variable is declared, if it is a state property.
   /// - Returns: The parsed `VariableDeclaration`.
   /// - Throws: If the token streams cannot be parsed as a `VariableDeclaration`.
-  func parseVariableDeclaration(asTypeProperty: Bool = false) throws -> VariableDeclaration {
+  func parseVariableDeclaration(enclosingType: RawTypeIdentifier? = nil) throws -> VariableDeclaration {
     let isConstant: Bool
 
     let declarationToken: Token
@@ -378,10 +377,12 @@ extension Parser {
       isConstant = true
     }
 
-    let name = try parseIdentifier()
+    var name = try parseIdentifier()
     let typeAnnotation = try parseTypeAnnotation()
 
     let assignedExpression: Expression?
+
+    let asTypeProperty = enclosingType != nil
 
     // If we are parsing a state property defined in a type, and it has been assigned a default value, parse it.
     if asTypeProperty, let equalToken = attempt(try consume(.punctuation(.equal))) {
@@ -391,6 +392,10 @@ extension Parser {
       assignedExpression = try parseExpression(upTo: newLineIndex)
     } else {
       assignedExpression = nil
+    }
+
+    if let enclosingType = enclosingType {
+      name.enclosingType = enclosingType
     }
 
     return VariableDeclaration(declarationToken: declarationToken, identifier: name, type: typeAnnotation.type, isConstant: isConstant, assignedExpression: assignedExpression)
@@ -736,7 +741,7 @@ extension Parser {
   func parseStructMembers(structIdentifier: Identifier) throws -> [StructMember] {
     var members = [StructMember]()
     while true {
-      if let variableDeclaration = attempt(try parseVariableDeclaration(asTypeProperty: true)) {
+      if let variableDeclaration = attempt(try parseVariableDeclaration(enclosingType: structIdentifier.name)) {
         members.append(.variableDeclaration(variableDeclaration))
       } else if let functionDeclaration = attempt(task: parseFunctionDeclaration) {
         members.append(.functionDeclaration(functionDeclaration))

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer.swift
@@ -64,11 +64,6 @@ public struct SemanticAnalyzer: ASTPass {
     } else {
       // This is a state property declaration.
 
-      // Constants need to have a value assigned.
-      if variableDeclaration.isConstant, variableDeclaration.assignedExpression == nil {
-        diagnostics.append(.constantStatePropertyIsNotAssignedAValue(variableDeclaration))
-      }
-
       // If a default value is assigned, it should be a literal.
 
       if let assignedExpression = variableDeclaration.assignedExpression {
@@ -126,6 +121,18 @@ public struct SemanticAnalyzer: ASTPass {
   }
 
   public func process(initializerDeclaration: InitializerDeclaration, passContext: ASTPassContext) -> ASTPassResult<InitializerDeclaration> {
+    let enclosingType = enclosingTypeIdentifier(in: passContext).name
+    let environment = passContext.environment!
+
+    // Gather properties of the enclosing type which haven't been assigned a default value.
+    let properties = environment.propertyDeclarations(in: enclosingType).filter { propertyDeclaration in
+      return propertyDeclaration.assignedExpression == nil
+    }
+
+    let passContext = passContext.withUpdates {
+      $0.unassignedProperties = properties
+    }
+
     return ASTPassResult(element: initializerDeclaration, diagnostics: [], passContext: passContext)
   }
 
@@ -154,17 +161,21 @@ public struct SemanticAnalyzer: ASTPass {
     var passContext = passContext
     var diagnostics = [Diagnostic]()
 
+    let inFunctionDeclaration = passContext.functionDeclarationContext != nil
+    let inInitializerDeclaration = passContext.initializerDeclarationContext != nil
+    let inFunctionOrInitializer = inFunctionDeclaration || inInitializerDeclaration
+
     if let isFunctionCall = passContext.isFunctionCall, isFunctionCall {
       // If the identifier is the name of a function call, do nothing. The function call will be matched in
       // `process(functionCall:passContext:)`.
-    } else if let functionDeclarationContext = passContext.functionDeclarationContext {
-      // The identifier is used within the body of a function.
+    } else if inFunctionOrInitializer {
+      // The identifier is used within the body of a function or an initializer
 
       // The identifier is used an l-value (the left-hand side of an assignment).
       let asLValue = passContext.asLValue ?? false
 
       if identifier.enclosingType == nil {
-        // The identifier has no explicit enclosing type, such as in the expression `a.foo`.
+        // The identifier has no explicit enclosing type, such as in the expression `foo` instead of `a.foo`.
 
         let scopeContext = passContext.scopeContext!
         if let variableDeclaration = scopeContext.variableDeclaration(for: identifier.name) {
@@ -187,21 +198,34 @@ public struct SemanticAnalyzer: ASTPass {
           diagnostics.append(.useOfUndeclaredIdentifier(identifier))
           passContext.environment!.addUsedUndefinedVariable(identifier, enclosingType: enclosingType)
         } else if asLValue {
+
           if passContext.environment!.isPropertyConstant(identifier.name, enclosingType: enclosingType) {
             // Retrieve the source location of that property's declaration.
             let declarationSourceLocation = passContext.environment!.propertyDeclarationSourceLocation(identifier.name, enclosingType: enclosingType)!
-
-            // The state property is a constant but is attempted to be reassigned.
-            diagnostics.append(.reassignmentToConstant(identifier, declarationSourceLocation))
+            
+            if !inInitializerDeclaration || passContext.environment!.isPropertyAssignedDefaultValue(identifier.name, enclosingType: enclosingType) {
+              // The state property is a constant but is attempted to be reassigned.
+              diagnostics.append(.reassignmentToConstant(identifier, declarationSourceLocation))
+            }
           }
 
-          // The variable is being mutated.
-          if !functionDeclarationContext.isMutating {
-            // The function is declared non-mutating.
-            diagnostics.append(.useOfMutatingExpressionInNonMutatingFunction(.identifier(identifier), functionDeclaration: functionDeclarationContext.declaration))
+          if let _ = passContext.initializerDeclarationContext {
+            // Check if the property has been marked as assigned yet.
+            if let first = passContext.unassignedProperties!.index(where: { $0.identifier.name == identifier.name && $0.identifier.enclosingType == identifier.enclosingType }) {
+              // Mark the property as assigned.
+              passContext.unassignedProperties!.remove(at: first)
+            }
           }
-          // Record the mutating expression in the context.
-          addMutatingExpression(.identifier(identifier), passContext: &passContext)
+
+          if let functionDeclarationContext = passContext.functionDeclarationContext {
+            // The variable is being mutated in a function.
+            if !functionDeclarationContext.isMutating {
+              // The function is declared non-mutating.
+              diagnostics.append(.useOfMutatingExpressionInNonMutatingFunction(.identifier(identifier), functionDeclaration: functionDeclarationContext.declaration))
+            }
+            // Record the mutating expression in the context.
+            addMutatingExpression(.identifier(identifier), passContext: &passContext)
+          }
         }
       }
     }
@@ -340,8 +364,6 @@ public struct SemanticAnalyzer: ASTPass {
     var diagnostics = [Diagnostic]()
     var passContext = passContext
 
-    var environmment = passContext.environment!
-
     // If we are in a contract behavior declaration, check there is only one public initializer.
     if let context = passContext.contractBehaviorDeclarationContext, initializerDeclaration.isPublic {
       let contractName = context.contractIdentifier.name
@@ -350,16 +372,20 @@ public struct SemanticAnalyzer: ASTPass {
       if !context.callerCapabilities.contains(where: { $0.isAny }) {
         diagnostics.append(.contractInitializerNotDeclaredInAnyCallerCapabilityBlock(initializerDeclaration))
       } else {
-        if let publicInitializer = environmment.publicInitializer(forContract: contractName) {
+        if let publicInitializer = passContext.environment!.publicInitializer(forContract: contractName) {
           diagnostics.append(.multiplePublicInitializersDefined(initializerDeclaration, originalInitializerLocation: publicInitializer.sourceLocation))
         } else {
           // This is the first public initializer we encounter in this contract.
-          environmment.setPublicInitializer(initializerDeclaration, forContract: contractName)
+          passContext.environment!.setPublicInitializer(initializerDeclaration, forContract: contractName)
         }
       }
     }
 
-    passContext.environment = environmment
+    // Check all the properties in the type have been assigned.
+    if let unassignedProperties = passContext.unassignedProperties, unassignedProperties.count > 0 {
+      diagnostics.append(.returnFromInitializerWithoutInitializingAllProperties(initializerDeclaration, unassignedProperties: unassignedProperties))
+    }
+
     return ASTPassResult(element: initializerDeclaration, diagnostics: diagnostics, passContext: passContext)
   }
 
@@ -482,8 +508,19 @@ extension ASTPassContext {
     get { return self[MutatingExpressionContextEntry.self] }
     set { self[MutatingExpressionContextEntry.self] = newValue }
   }
+
+  /// The list of unassigned properties in a type.
+  var unassignedProperties: [VariableDeclaration]? {
+    get { return self[UnassignedPropertiesContextEntry.self] }
+    set { self[UnassignedPropertiesContextEntry.self] = newValue }
+  }
 }
 
 struct MutatingExpressionContextEntry: PassContextEntry {
   typealias Value = [Expression]
 }
+
+struct UnassignedPropertiesContextEntry: PassContextEntry {
+  typealias Value = [VariableDeclaration]
+}
+

--- a/Sources/SemanticAnalyzer/SemanticError.swift
+++ b/Sources/SemanticAnalyzer/SemanticError.swift
@@ -56,8 +56,8 @@ extension Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: variableDeclaration.sourceLocation, message: "The default value assigned to a state property must be a literal")
   }
 
-  static func constantStatePropertyIsNotAssignedAValue(_ variableDeclaration: VariableDeclaration) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: variableDeclaration.sourceLocation, message: "'let' constant '\(variableDeclaration.identifier.name)' needs to be assigned a value")
+  static func statePropertyIsNotAssignedAValue(_ variableDeclaration: VariableDeclaration) -> Diagnostic {
+    return Diagnostic(severity: .error, sourceLocation: variableDeclaration.sourceLocation, message: "State property '\(variableDeclaration.identifier.name)' needs to be assigned a value")
   }
 
   static func returnFromInitializerWithoutInitializingAllProperties(_ initializerDeclaration: InitializerDeclaration, unassignedProperties: [VariableDeclaration]) -> Diagnostic {

--- a/Sources/SemanticAnalyzer/SemanticError.swift
+++ b/Sources/SemanticAnalyzer/SemanticError.swift
@@ -49,7 +49,7 @@ extension Diagnostic {
 
   static func reassignmentToConstant(_ identifier: Identifier, _ declarationSourceLocation: SourceLocation) -> Diagnostic {
     let note = Diagnostic(severity: .note, sourceLocation: declarationSourceLocation, message: "'\(identifier.name)' is declared here")
-    return Diagnostic(severity: .error, sourceLocation: identifier.sourceLocation, message: "Cannot assign to value: '\(identifier.name)' is a 'let' constant", notes: [note])
+    return Diagnostic(severity: .error, sourceLocation: identifier.sourceLocation, message: "Cannot reassign to value: '\(identifier.name)' is a 'let' constant", notes: [note])
   }
 
   static func statePropertyDeclarationIsAssignedANonLiteralExpression(_ variableDeclaration: VariableDeclaration) -> Diagnostic {
@@ -58,6 +58,14 @@ extension Diagnostic {
 
   static func constantStatePropertyIsNotAssignedAValue(_ variableDeclaration: VariableDeclaration) -> Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: variableDeclaration.sourceLocation, message: "'let' constant '\(variableDeclaration.identifier.name)' needs to be assigned a value")
+  }
+
+  static func returnFromInitializerWithoutInitializingAllProperties(_ initializerDeclaration: InitializerDeclaration, unassignedProperties: [VariableDeclaration]) -> Diagnostic {
+    let notes = unassignedProperties.map { property in
+      return Diagnostic(severity: .note, sourceLocation: property.sourceLocation, message: "\(property.identifier.name) is uninitialized")
+    }
+
+    return Diagnostic(severity: .error, sourceLocation: initializerDeclaration.closeBraceToken.sourceLocation, message: "Return from initializer without initializing all properties", notes: notes)
   }
 
   static func multiplePublicInitializersDefined(_ invalidAdditionalInitializer: InitializerDeclaration, originalInitializerLocation: SourceLocation) -> Diagnostic {

--- a/Sources/SemanticAnalyzer/TypeChecker.swift
+++ b/Sources/SemanticAnalyzer/TypeChecker.swift
@@ -67,7 +67,9 @@ public struct TypeChecker: ASTPass {
         rhsType = nil
       }
 
-      if let rhsType = rhsType, !lhsType.isCompatible(with: rhsType), ![lhsType, rhsType].contains(.errorType) {
+      // Numeric literals can be assigned to Wei properties (until we support struct initializers)
+      if let rhsType = rhsType, rhsType == .basicType(.int), lhsType == .basicType(.wei) {
+      } else if let rhsType = rhsType, !lhsType.isCompatible(with: rhsType), ![lhsType, rhsType].contains(.errorType) {
         diagnostics.append(.incompatibleAssignment(lhsType: lhsType, rhsType: rhsType, expression: assignedExpression))
       }
     }

--- a/Tests/BehaviorTests/tests/array/array.flint
+++ b/Tests/BehaviorTests/tests/array/array.flint
@@ -1,9 +1,9 @@
 contract Array {
-  var arr: Int[4]
-  var arr2: Int[10]
-  var numWrites: Int
+  var arr: Int[4] = []
+  var arr2: Int[10] = []
+  var numWrites: Int = 0
 
-  var arr3: [S]
+  var arr3: [S] = []
 }
 
 Array :: (any) {

--- a/Tests/BehaviorTests/tests/bank/bank.flint
+++ b/Tests/BehaviorTests/tests/bank/bank.flint
@@ -1,10 +1,10 @@
 contract Bank {
   var manager: Address
-  var balances: [Address: Int]
-  var accounts: [Address]
-  var lastIndex: Int
+  var balances: [Address: Int] = [:]
+  var accounts: [Address] = []
+  var lastIndex: Int = 0
 
-  var totalDonations: Wei
+  var totalDonations: Wei = 0
 }
 
 Bank :: account <- (any) {

--- a/Tests/BehaviorTests/tests/dictionary/dictionary.flint
+++ b/Tests/BehaviorTests/tests/dictionary/dictionary.flint
@@ -1,10 +1,10 @@
 contract Dictionary {
-  var storage: [Address: Int]
-  var foo: Int
-  var storage2: [Address: Int]
-  var bar: Int
+  var storage: [Address: Int] = [:]
+  var foo: Int = 0
+  var storage2: [Address: Int] = [:]
+  var bar: Int = 0
 
-  var storage3: [Int: S]
+  var storage3: [Int: S] = [:]
 }
 
 struct S {

--- a/Tests/BehaviorTests/tests/factorial/factorial.flint
+++ b/Tests/BehaviorTests/tests/factorial/factorial.flint
@@ -1,5 +1,5 @@
 contract Factorial {
-  var value: Int
+  var value: Int = 0
 }
 
 Factorial :: (any) {

--- a/Tests/ParserTests/array.flint
+++ b/Tests/ParserTests/array.flint
@@ -29,15 +29,23 @@ contract Test {
 // CHECK-AST: VariableDeclaration
 // CHECK-AST:   identifier "numWrites"
 // CHECK-AST:   built-in type Int
-  var numWrites: Int
+// CHECK-AST:   0
+  var numWrites: Int = 0
 }
 
 // CHECK-AST: TopLevelDeclaration
 // CHECK-AST: ContractBehaviorDeclaration
 // CHECK-AST:   identifier "Test"
+// CHECK-AST:   capability binding "caller"
 // CHECK-AST:   CallerCapability
 // CHECK-AST:     identifier "any"
-Test :: (any) {
+Test :: caller <- (any) {
+  
+// CHECK-AST: InitializerDeclaration
+// CHECK-AST:   public
+  public init() {
+    self.owner = caller
+  }
 
 // CHECK-AST: FunctionDeclaration
 // CHECK-AST:   mutating

--- a/Tests/ParserTests/branching.flint
+++ b/Tests/ParserTests/branching.flint
@@ -2,10 +2,14 @@
 
 contract Wallet {
   var owner: Address
-  var contents: Int
+  var contents: Int = 0
 }
 
 Wallet :: (any) {
+  public init(owner: Address) {
+    self.owner = owner
+  }
+
   public func factorial(n: Int) -> Int {
 
 // CHECK-AST: IfStatement

--- a/Tests/ParserTests/types.flint
+++ b/Tests/ParserTests/types.flint
@@ -8,7 +8,7 @@ contract Foo {
 // CHECK-AST:  FixedSizeArrayType
 // CHECK-AST:   built-in type Int
 // CHECK-AST:   size 16
-  var array: Int[16]
+  var array: Int[16] = []
 
 // CHECK-AST: VariableDeclaration
 // CHECK-AST:  identifier "dictionary"
@@ -21,7 +21,7 @@ contract Foo {
 // CHECK-AST: VariableDeclaration
 // CHECK-AST:   identifier "value"
 // CHECK-AST:   built-in type Int
-  var value: Int
+  var value: Int = 0
 
 // CHECK-AST: VariableDeclaration
 // CHECK-AST:   identifier "didCompleteSomething"

--- a/Tests/SemanticTests/constants.flint
+++ b/Tests/SemanticTests/constants.flint
@@ -1,34 +1,34 @@
 // RUN: %flintc %s --verify
 
 contract Constants {
-  var a: Int
+  var a: Int // expected-error {{State property 'a' needs to be assigned a value}}
   var b: Int = "a" // expected-error {{Incompatible assignment between values of type Int and String}}
   let c: Int = 2 + 3 // expected-error {{The default value assigned to a state property must be a literal}}
   let d: Int = 3
-  let e: Int // expected-error {{'let' constant 'e' needs to be assigned a value}}
+  let e: Int // expected-error {{State property 'e' needs to be assigned a value}}
 }
 
 Constants :: (any) {
   mutating func foo() {
     let a: Int = 2 // expected-note {{'a' is declared here}}
-    a = 3 // expected-error {{Cannot assign to value: 'a' is a 'let' constant}}
+    a = 3 // expected-error {{Cannot reassign to value: 'a' is a 'let' constant}}
 
     let b: Int = a
     self.a = 3
 
     if true {
-      a = 5 // expected-error {{Cannot assign to value: 'a' is a 'let' constant}}
+      a = 5 // expected-error {{Cannot reassign to value: 'a' is a 'let' constant}}
     } else {
-      a = 7 // expected-error {{Cannot assign to value: 'a' is a 'let' constant}}
+      a = 7 // expected-error {{Cannot reassign to value: 'a' is a 'let' constant}}
     }
 
-    d = 4 // expected-error {{Cannot assign to value: 'd' is a 'let' constant}}
+    d = 4 // expected-error {{Cannot reassign to value: 'd' is a 'let' constant}}
   }
 
   mutating func bar() {
     var d: Bool = true
     d = false
 
-    self.d = 5 // expected-error {{Cannot assign to value: 'd' is a 'let' constant}}
+    self.d = 5 // expected-error {{Cannot reassign to value: 'd' is a 'let' constant}}
   }
 }

--- a/Tests/SemanticTests/inits.flint
+++ b/Tests/SemanticTests/inits.flint
@@ -17,10 +17,12 @@ Test :: caller <- (any) {
   }
 
   init() {
+    self.a = caller
   }
 }
 
 Test :: (a) {
   public init(a: Address) { // expected-error {{Public contract initializer should be callable using caller capability "any"}}
+    self.a = a
   }
 }

--- a/Tests/SemanticTests/invalid_function_call.flint
+++ b/Tests/SemanticTests/invalid_function_call.flint
@@ -4,10 +4,14 @@ contract Test {
   var owner: Address
 }
 
-Test :: (any) {
+Test :: caller <- (any) {
+  public init() {
+    self.owner = caller
+  }
+
   public func foo() {
 
-// expected-error@11 {{Function bar is not in scope or cannot be called using the caller capabilities (any)}}
+// expected-error@15 {{Function bar is not in scope or cannot be called using the caller capabilities (any)}}
     bar()
   }
 }

--- a/Tests/SemanticTests/invalid_types.flint
+++ b/Tests/SemanticTests/invalid_types.flint
@@ -1,8 +1,8 @@
 // RUN: %flintc %s --verify
 
 contract InvalidTypes {
-  var int: Int
-  var a: Int
+  var int: Int = 0
+  var a: Int = 0
 }
 
 InvalidTypes :: (any) {

--- a/Tests/SemanticTests/mutating.flint
+++ b/Tests/SemanticTests/mutating.flint
@@ -1,8 +1,8 @@
 // RUN: %flintc %s --verify
 
 contract Test {
-  var a: Int[10]
-  var b: Int
+  var a: Int[10] = []
+  var b: Int = 0
   var f: Foo
 }
 

--- a/Tests/SemanticTests/structs.flint
+++ b/Tests/SemanticTests/structs.flint
@@ -13,7 +13,7 @@ struct Test2 {
 }
 
 contract Foo {
-  var c: Int
+  var c: Int = 0
   var a: Test
   var b: Test2
 }

--- a/Tests/SemanticTests/undeclared_capability.flint
+++ b/Tests/SemanticTests/undeclared_capability.flint
@@ -4,6 +4,12 @@ contract Test {
   var owner: Address
 }
 
+Test :: caller <- (any) {
+  public init() {
+    self.owner = owner
+  }
+}
+
 Test :: (alice) { // expected-error {{Caller capability alice is undefined in Test or has incompatible type}}
   func bar() {
   }

--- a/Tests/SemanticTests/use_undeclared_identifier.flint
+++ b/Tests/SemanticTests/use_undeclared_identifier.flint
@@ -1,7 +1,7 @@
 // RUN: %flintc %s --verify
 
 contract Test {
-  var x: Int
+  var x: Int = 0
 }
 
 Test :: (any) {


### PR DESCRIPTION
Contracts properties need to be assigned a default value, or if a public initializer is defined, they need be set within in.

```swift
contract A {
  var a: Int = 0
  var b: Int
  var c: Address
}

A :: caller <- (any) {
  public init(b: Int) {
    self.b = b
  } // error: return from initializer without initializing all stored properties

  // Fix:
  // public init(b: Int) {
  //   self.b = b
  //   self.c = caller
  // }
}
```