### PR TITLE
Support struct initializers

### DIFF
--- a/Sources/AST/AST.swift
+++ b/Sources/AST/AST.swift
@@ -49,9 +49,17 @@ public struct ContractDeclaration: SourceEntity {
 ///
 /// - functionDeclaration: The declaration of a function.
 /// - initializerDeclaration: The declaration of an initializer.
-public enum ContractBehaviorMember: Equatable {
+public enum ContractBehaviorMember: Equatable, SourceEntity {
   case functionDeclaration(FunctionDeclaration)
   case initializerDeclaration(InitializerDeclaration)
+
+  public var sourceLocation: SourceLocation {
+    switch self {
+    case .functionDeclaration(let functionDeclaration): return functionDeclaration.sourceLocation
+    case .initializerDeclaration(let initializerDeclaration): return initializerDeclaration.sourceLocation
+    }
+  }
+
 }
 
 /// A Flint contract behavior declaration, i.e. the functions of a contract for a given caller capability group.
@@ -106,6 +114,13 @@ public struct StructDeclaration: SourceEntity {
     return members.compactMap { member in
       guard case .functionDeclaration(let functionDeclaration) = member else { return nil }
       return functionDeclaration
+    }
+  }
+
+  public var initializerDeclarations: [InitializerDeclaration] {
+    return members.compactMap { member in
+      guard case .initializerDeclaration(let initializerDeclaration) = member else { return nil }
+      return initializerDeclaration
     }
   }
 
@@ -218,6 +233,7 @@ public struct FunctionDeclaration: SourceEntity {
   }
 }
 
+/// The declaration of an initializer.
 public struct InitializerDeclaration: SourceEntity {
   public var initToken: Token
 

--- a/Sources/AST/ASTVisitor.swift
+++ b/Sources/AST/ASTVisitor.swift
@@ -371,6 +371,7 @@ public struct ASTVisitor<Pass: ASTPass> {
     }
 
     let postProcessResult = pass.postProcess(functionCall: processResult.element, passContext: processResult.passContext)
+
     return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
   }
 

--- a/Sources/AST/Environment.swift
+++ b/Sources/AST/Environment.swift
@@ -159,8 +159,13 @@ public struct Environment {
 
   /// The type return type of a function call, determined by looking up the function's declaration.
   public func type(of functionCall: FunctionCall, enclosingType: RawTypeIdentifier, callerCapabilities: [CallerCapability], scopeContext: ScopeContext) -> Type.RawType? {
-    guard case .matchedFunction(let matchingFunction) = matchFunctionCall(functionCall, enclosingType: enclosingType, callerCapabilities: callerCapabilities, scopeContext: scopeContext) else { return .errorType }
-    return matchingFunction.resultType
+    let match = matchFunctionCall(functionCall, enclosingType: enclosingType, callerCapabilities: callerCapabilities, scopeContext: scopeContext)
+    
+    switch match {
+    case .matchedFunction(let matchingFunction): return matchingFunction.resultType
+    case .matchedInitializer(_): return .userDefinedType(functionCall.identifier.name)
+    default: return .errorType
+    }
   }
 
   /// The types a literal token can be.

--- a/Sources/IRGen/EVM.swift
+++ b/Sources/IRGen/EVM.swift
@@ -1,0 +1,14 @@
+//
+//  EVM.swift
+//  IRGen
+//
+//  Created by Franklin Schrans on 5/3/18.
+//
+
+/// Constants related to EVM.
+enum EVM {
+  /// The size of an EVM storage location, in bytes.
+  static var wordSize: Int {
+    return 32
+  }
+}

--- a/Sources/IRGen/Function/IULIAContractInitializer.swift
+++ b/Sources/IRGen/Function/IULIAContractInitializer.swift
@@ -7,8 +7,8 @@
 
 import AST
 
-/// Generates code for an initializer.
-struct IULIAInitializer {
+/// Generates code for a contract initializer.
+struct IULIAContractInitializer {
   var initializerDeclaration: InitializerDeclaration
   var typeIdentifier: Identifier
 
@@ -45,14 +45,14 @@ struct IULIAInitializer {
     let parameterSizes = initializerDeclaration.explicitParameters.map { environment.size(of: $0.type.rawType) }
     let offsetsAndSizes = zip(parameterSizes.reversed().reduce((0, [Int]())) { (acc, element) in
       let (size, sizes) = acc
-      let nextSize = size + element * 32
+      let nextSize = size + element * EVM.wordSize
       return (nextSize, sizes + [nextSize])
     }.1.reversed(), parameterSizes)
 
     let parameterBindings = zip(parameterNames, offsetsAndSizes).map { arg -> String in
       let (parameter, (offset, size)) = arg
       return """
-      codecopy(0x0, sub(codesize, \(offset)), \(size * 32))
+      codecopy(0x0, sub(codesize, \(offset)), \(size * EVM.wordSize))
       let \(parameter) := mload(0)
       """
     }.joined(separator: "\n")

--- a/Sources/IRGen/Function/IULIAExpression.swift
+++ b/Sources/IRGen/Function/IULIAExpression.swift
@@ -64,7 +64,7 @@ struct IULIABinaryExpression {
       }
       return IULIAPropertyAccess(lhs: binaryExpression.lhs, rhs: binaryExpression.rhs, asLValue: asLValue).rendered(functionContext: functionContext)
     }
-    
+
     let lhs = IULIAExpression(expression: binaryExpression.lhs, asLValue: asLValue).rendered(functionContext: functionContext)
     let rhs = IULIAExpression(expression: binaryExpression.rhs, asLValue: asLValue).rendered(functionContext: functionContext)
 
@@ -151,12 +151,6 @@ struct IULIAAssignment {
   var rhs: Expression
   
   func rendered(functionContext: FunctionContext, asTypeProperty: Bool = false) -> String {
-    if !asTypeProperty {
-      guard !functionContext.environment.type(of: rhs, enclosingType: functionContext.enclosingTypeName, scopeContext: functionContext.scopeContext).isDynamicType else {
-        fatalError("Assigning dynamic types is not supported yet.")
-      }
-    }
-
     let rhsCode = IULIAExpression(expression: rhs).rendered(functionContext: functionContext)
     
     switch lhs {
@@ -204,10 +198,10 @@ struct IULIAEventCall {
     for (i, argument) in eventCall.arguments.enumerated() {
       let argument = IULIAExpression(expression: argument)
       stores.append("mstore(\(memoryOffset), \(argument))")
-      memoryOffset += functionContext.environment.size(of: types[i]) * 32
+      memoryOffset += functionContext.environment.size(of: types[i]) * EVM.wordSize
     }
     
-    let totalSize = types.reduce(0) { return $0 + functionContext.environment.size(of: $1) } * 32
+    let totalSize = types.reduce(0) { return $0 + functionContext.environment.size(of: $1) } * EVM.wordSize
     let typeList = eventInformation.typeGenericArguments.map { type in
       return "\(CanonicalType(from: type)!.rawValue)"
       }.joined(separator: ",")

--- a/Sources/IRGen/IULIAStruct.swift
+++ b/Sources/IRGen/IULIAStruct.swift
@@ -1,0 +1,24 @@
+//
+//  IULIAStruct.swift
+//  IRGen
+//
+//  Created by Franklin Schrans on 5/3/18.
+//
+
+import AST
+
+/// Generates code for a struct. Structs functions and initializers are embedded in the contract.
+public struct IULIAStruct {
+  var structDeclaration: StructDeclaration
+  var environment: Environment
+
+  func rendered() -> String {
+    // At this point, the initializers have been converted to functions.
+    
+    let functionsCode = structDeclaration.functionDeclarations.compactMap { functionDeclaration in
+      return IULIAFunction(functionDeclaration: functionDeclaration, typeIdentifier: structDeclaration.identifier, environment: environment).rendered()
+    }.joined(separator: "\n\n")
+
+    return functionsCode
+  }
+}

--- a/Sources/IRGen/Mangler.swift
+++ b/Sources/IRGen/Mangler.swift
@@ -9,4 +9,8 @@ struct Mangler {
   static func mangleName(_ name: String, enclosingType: String? = nil) -> String {
     return "\(enclosingType ?? "")_\(name)"
   }
+
+  static func mangleInitializer(enclosingType: String) -> String {
+    return "\(enclosingType)_init"
+  }
 }

--- a/Sources/Parser/Parser.swift
+++ b/Sources/Parser/Parser.swift
@@ -754,10 +754,12 @@ extension Parser {
         environment.addFunction(functionDeclaration, enclosingType: structIdentifier.name)
       } else if let initializerDeclaration = attempt(task: parseInitializerDeclaration) {
         members.append(.initializerDeclaration(initializerDeclaration))
+        environment.addInitializer(initializerDeclaration, enclosingType: structIdentifier.name)
       } else {
         break
       }
     }
+
     return members
   }
 

--- a/Sources/SemanticAnalyzer/SemanticError.swift
+++ b/Sources/SemanticAnalyzer/SemanticError.swift
@@ -72,7 +72,7 @@ extension Diagnostic {
     let note = Diagnostic(severity: .note, sourceLocation: originalInitializerLocation, message: "A public initializer is already declared here")
     return Diagnostic(severity: .error, sourceLocation: invalidAdditionalInitializer.sourceLocation, message: "A public initializer has already been defined", notes: [note])
   }
-
+  
   static func contractInitializerNotDeclaredInAnyCallerCapabilityBlock(_ initializerDeclaration: InitializerDeclaration) -> Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: initializerDeclaration.sourceLocation, message: "Public contract initializer should be callable using caller capability \"any\"")
   }

--- a/Tests/BehaviorTests/tests/array/array.flint
+++ b/Tests/BehaviorTests/tests/array/array.flint
@@ -57,11 +57,11 @@ Array :: (any) {
 }
 
 struct S {
-  var a: Int
-  var b: Bool
+  var a: Int = 0
+  var b: Bool = false
   var c: T
 }
 
 struct T {
-  var a: Int
+  var a: Int = 0
 }

--- a/Tests/BehaviorTests/tests/dictionary/dictionary.flint
+++ b/Tests/BehaviorTests/tests/dictionary/dictionary.flint
@@ -8,13 +8,13 @@ contract Dictionary {
 }
 
 struct S {
-  var a: Int
-  var b: Bool
+  var a: Int = 0
+  var b: Bool = false
   var c: T
 } 
 
 struct T {
-  var a: Int
+  var a: Int = 0
 }
 
 Dictionary :: (any) {

--- a/Tests/BehaviorTests/tests/inits/inits.flint
+++ b/Tests/BehaviorTests/tests/inits/inits.flint
@@ -2,6 +2,8 @@ contract Inits {
   var a: Int
   var b: Address
   var s: String
+  var s1: String = "foo"
+  var t: T
 }
 
 Inits :: caller <- (any) {
@@ -21,5 +23,36 @@ Inits :: caller <- (any) {
 
   public func getS() -> String {
     return s
+  }
+
+  public func getS1() -> String {
+    return s1
+  }
+
+  public mutating func setT(x: Int, y: Bool) {
+    t = T(x, y)
+  }
+
+  public func getTx() -> Int {
+    return t.x
+  }
+
+  public func getTy() -> Bool {
+    return t.y
+  }
+
+  public func getTs() -> String {
+    return t.s
+  }
+}
+
+struct T {
+  var x: Int
+  var y: Bool
+  let s: String = "test"
+  
+  public init(x: Int, y: Bool) {
+    self.x = x
+    self.y = y
   }
 }

--- a/Tests/BehaviorTests/tests/inits/test/test/test.js
+++ b/Tests/BehaviorTests/tests/inits/test/test/test.js
@@ -1,3 +1,5 @@
+// RUN: cd %S && truffle test
+
 var config = require("../config.js")
 
 var Contract = artifacts.require("./" + config.contractName + ".sol");
@@ -5,11 +7,11 @@ var Interface = artifacts.require("./_Interface" + config.contractName + ".sol")
 Contract.abi = Interface.abi
 
 contract(config.contractName, function(accounts) {
-  it("should correctly set initializer arguments", async function() {
+  it("should correctly set initializer arguments for contracts", async function() {
     const instance = await Contract.deployed();
     let t;
 
-    t = await instance.getX();
+    t = await instance.getA();
     assert.equal(t.valueOf(), 4);
     
     t = await instance.getB();
@@ -17,6 +19,25 @@ contract(config.contractName, function(accounts) {
 
     t = await instance.getS();
     assert.equal(web3.toUtf8(t.valueOf()), "hello");
+
+    t = await instance.getS1();
+    assert.equal(web3.toUtf8(t.valueOf()), "foo");
+  });
+
+  it("should correctly set initializer arguments for structs", async function() {
+    const instance = await Contract.deployed();
+    let t;
+
+    await instance.setT(10, 1);
+
+    t = await instance.getTx();
+    assert.equal(t.valueOf(), 10);
+    
+    t = await instance.getTy();
+    assert.equal(t.valueOf(), 1);
+
+    t = await instance.getTs();
+    assert.equal(web3.toUtf8(t.valueOf()), "test");
   });
 });
 

--- a/Tests/BehaviorTests/tests/structs/structs.flint
+++ b/Tests/BehaviorTests/tests/structs/structs.flint
@@ -1,6 +1,6 @@
 struct A {
-  var x: Int
-  var y: Bool
+  var x: Int = 0
+  var y: Bool = false
 
   func getX() -> Int {
     return x
@@ -13,7 +13,7 @@ struct A {
 
 struct B {
   var x: A
-  var y: Int
+  var y: Int = 0
 
   func getXx() -> Int {
     return x.getX()
@@ -126,8 +126,8 @@ C :: (any) {
 }
 
 struct Array {
-  var elements: [Int]
-  var size: Int
+  var elements: [Int] = []
+  var size: Int = 0
 
   mutating func add(value: Int) {
     elements[size] = value

--- a/Tests/SemanticTests/inits.flint
+++ b/Tests/SemanticTests/inits.flint
@@ -8,6 +8,7 @@ contract Test {
   var e: Bool
   var f: Int
   let g: Bool
+  var x: B
 }
 
 Test :: caller <- (any) {
@@ -31,7 +32,10 @@ Test :: caller <- (any) {
     g = false
   }
 
-  func foo() {}
+  mutating func foo() {
+    x = B(1, true) 
+    x = C(1) // expected-error {{Incompatible assignment between values of type B and C}}
+  }
 }
 
 Test :: (a) {
@@ -49,10 +53,24 @@ struct A {
   var c: C
 }
 
+struct B {
+  var a: Int = 0
+  var b: Bool
+  var c: C
+
+  init(a: Int, b: Bool) {
+    self.a = a
+    self.b = b
+  }
+}
+
 struct C {
-  var a: Int
+  var a: Int // expected-note {{a is uninitialized}}
   let b: Bool = false
 
   init() {} // expected-error {{Return from initializer without initializing all properties}}
-  // expected-note@53 {{a is uninitialized}}
+
+  init(a: Int) {
+    self.a = a
+  }
 }

--- a/Tests/SemanticTests/inits.flint
+++ b/Tests/SemanticTests/inits.flint
@@ -1,28 +1,58 @@
 // RUN: %flintc %s --verify
 
 contract Test {
-  var a: Address
+  let a: Address
   var b: [Address] = []
   var c: [Address: Int] = [] // expected-error {{Incompatible assignment between values of type [Address: Int] and [Any]}}
   var d: [Int] = [:] // expected-error {{Incompatible assignment between values of type [Int] and [Any: Any]}}
+  var e: Bool
+  var f: Int
+  let g: Bool
 }
 
 Test :: caller <- (any) {
-  public init(a: Address) { // expected-note {{A public initializer is already declared here}}
+  public init(a: Address, f: Int) { // expected-note {{A public initializer is already declared here}}
     self.a = a
-  }
+    self.f = f
+  } // expected-error {{Return from initializer without initializing all properties}}
+  // expected-note@8 {{e is uninitialized}}
 
   public init() { // expected-error {{A public initializer has already been defined}}
     self.a = caller
+    e = false
+    f = 0
+    g = false
   }
 
   init() {
     self.a = caller
+    e = false
+    f = 0
+    g = false
   }
+
+  func foo() {}
 }
 
 Test :: (a) {
   public init(a: Address) { // expected-error {{Public contract initializer should be callable using caller capability "any"}}
     self.a = a
+    e = false
+    f = 0
+    g = false
   }
+}
+
+struct A {
+  var a: Int = 0
+  var b: Bool // expected-error {{State property 'b' needs to be assigned a value}}
+  var c: C
+}
+
+struct C {
+  var a: Int
+  let b: Bool = false
+
+  init() {} // expected-error {{Return from initializer without initializing all properties}}
+  // expected-note@53 {{a is uninitialized}}
 }

--- a/Tests/SemanticTests/mutating.flint
+++ b/Tests/SemanticTests/mutating.flint
@@ -65,7 +65,7 @@ Test :: (any) {
 }
 
 struct Foo {
-  var a: Int
+  var a: Int = 0
 
   func h() { 
     a = 2 // expected-error {{Use of mutating statement in a nonmutating function}}

--- a/Tests/SemanticTests/structs.flint
+++ b/Tests/SemanticTests/structs.flint
@@ -1,7 +1,7 @@
 // RUN: %flintc %s --verify
 
 struct Test {
-  var a: Int
+  var a: Int = 0
 
   func foo() -> Int {
     return 2

--- a/examples/valid/Marking.flint
+++ b/examples/valid/Marking.flint
@@ -1,9 +1,15 @@
 contract Marking {
   var lecturer: Address
-  var markers: [Address]
-  var numMarkers: Int
+  var markers: [Address] = []
+  var numMarkers: Int = 0
   
-  var grades: [Address: Int]
+  var grades: [Address: Int] = [:]
+}
+
+Marking :: (any) {
+  public init(lecturer: Address) {
+    self.lecturer = lecturer
+  }
 }
 
 Marking :: (lecturer) {

--- a/examples/valid/array.flint
+++ b/examples/valid/array.flint
@@ -1,11 +1,15 @@
 contract Test {
   var owner: Address
-  var arr: Int[4]
-  var arr2: Int[10]
-  var numWrites: Int
+  var arr: Int[4] = []
+  var arr2: Int[10] = []
+  var numWrites: Int = 0
 }
 
-Test :: (any) {
+Test :: caller <- (any) {
+  public init() {
+    self.owner = caller
+  }
+  
   mutating func increaseNumWrites() {
     self.numWrites += 1 
   }

--- a/examples/valid/bank.flint
+++ b/examples/valid/bank.flint
@@ -1,14 +1,19 @@
 contract Bank {
   var manager: Address
-  var balances: [Address: Int]
-  var accounts: [Address]
-  var lastIndex: Int
+  var balances: [Address: Int] = [:]
+  var accounts: [Address] = []
+  var lastIndex: Int = 0
 
-  var totalDonations: Wei
+  var totalDonations: Wei = 0
   var didCompleteTransfer: Event<Address, Address, Int>
 }
 
 Bank :: account <- (any) {
+
+  public init(manager: Address) {
+    self.manager = manager
+  }
+
   public mutating func register() {
     accounts[lastIndex] = account
     lastIndex += 1

--- a/examples/valid/branching.flint
+++ b/examples/valid/branching.flint
@@ -1,5 +1,5 @@
 contract Test {
-  var data: Int
+  var data: Int = 0
 }
 
 Test :: (any) {

--- a/examples/valid/counter.flint
+++ b/examples/valid/counter.flint
@@ -1,5 +1,5 @@
 contract Counter {
-  var value: Int
+  var value: Int = 0
 }
 
 Counter :: (any) {

--- a/examples/valid/data_types.flint
+++ b/examples/valid/data_types.flint
@@ -1,12 +1,17 @@
 contract Test {
-  var test: Int
-  var dict: [Address: Int]
-  var arr: Address[10]
+  var test: Int = 0
+  var dict: [Address: Int] = [:]
+  var arr: Address[10] = []
   var p1: Address
   var p2: Address
 }
 
 Test :: (any) {
+  public init(p1: Address, p2: Address) {
+    self.p1 = p1
+    self.p2 = p2
+  }
+
   public mutating func setP1(p1: Address) {
     self.p1 = p1
   }

--- a/examples/valid/dictionary.flint
+++ b/examples/valid/dictionary.flint
@@ -1,8 +1,8 @@
 contract Dictionary {
-  var storage: [Address: Int]
-  var foo: Int
-  var storage2: [Address: Int]
-  var bar: Int
+  var storage: [Address: Int] = [:]
+  var foo: Int = 0
+  var storage2: [Address: Int] = [:]
+  var bar: Int = 0
 }
 
 Dictionary :: (any) {

--- a/examples/valid/explicit_self_references.flint
+++ b/examples/valid/explicit_self_references.flint
@@ -1,5 +1,5 @@
 contract ExplicitSelfReference {
-  var property: Int
+  var property: Int = 0
 }
 
 ExplicitSelfReference :: (any) {

--- a/examples/valid/main.flint
+++ b/examples/valid/main.flint
@@ -1,5 +1,5 @@
 contract Factorial {
-  var value: Int
+  var value: Int = 0
 }
 
 Factorial :: (any) {

--- a/examples/valid/wallet.flint
+++ b/examples/valid/wallet.flint
@@ -1,20 +1,24 @@
 contract Wallet {
   var owner: Address
-  var contents: Ether
+  var contents: Wei = 0 
 }
 
-Wallet :: (any) {
-  public mutating func deposit(money: Ether) {
+Wallet :: caller <- (any) {
+  public init() {
+    owner = caller
+  }
+
+  public mutating func deposit(money: Wei) {
     contents += money;
   }
 }
 
 Wallet :: (owner) {
-  public mutating func withdraw(money: Ether) {
+  public mutating func withdraw(money: Wei) {
     contents -= money;
   }
 
-  public func getContents(a: Int) -> Ether {
+  public func getContents(a: Int) -> Wei {
     return contents;
   }
 }


### PR DESCRIPTION
This PR resolves #111. Declaring structs as local variables is not supported yet.

Declaration:
```swift
struct A {
  var value: Int

  init(value: Int) {
    self.value = value
  }
}
```

Calling an initializer:
```swift
func foo() {
  self.a = A(2)
}
```