### PR TITLE
Disallow redeclarations of identifiers

### DIFF
--- a/Sources/AST/ASTPass.swift
+++ b/Sources/AST/ASTPass.swift
@@ -285,6 +285,8 @@ public struct AnyASTPass: ASTPass {
 
 extension ASTPass {
   public func enclosingTypeIdentifier(in passContext: ASTPassContext) -> Identifier {
-    return passContext.contractBehaviorDeclarationContext?.contractIdentifier ?? passContext.structDeclarationContext!.structIdentifier
+    return passContext.contractBehaviorDeclarationContext?.contractIdentifier ??
+      passContext.structDeclarationContext?.structIdentifier ??
+      passContext.contractStateDeclarationContext!.contractIdentifier
   }
 }

--- a/Sources/SemanticAnalyzer/SemanticError.swift
+++ b/Sources/SemanticAnalyzer/SemanticError.swift
@@ -10,6 +10,11 @@ import AST
 // MARK: Errors
 
 extension Diagnostic {
+  static func invalidRedeclaration(_ identifier: Identifier, originalSource: Identifier) -> Diagnostic {
+    let note = Diagnostic(severity: .note, sourceLocation: originalSource.sourceLocation, message: "\(originalSource.name) is declared here")
+    return Diagnostic(severity: .error, sourceLocation: identifier.sourceLocation, message: "Invalid redeclaration of \(identifier.name)", notes: [note])
+  }
+
   static func noMatchingFunctionForFunctionCall(_ functionCall: FunctionCall, contextCallerCapabilities: [CallerCapability], candidates: [FunctionInformation]) -> Diagnostic {
 
     let candidateNotes = candidates.map { candidate in

--- a/Tests/SemanticTests/invalid_redeclarations.flint
+++ b/Tests/SemanticTests/invalid_redeclarations.flint
@@ -1,0 +1,27 @@
+// RUN: %flintc %s --verify
+
+contract A {
+  let x: Int = 0
+  let x: Int = 2 // expected-error {{Invalid redeclaration of x}}
+}
+
+A :: caller <- (any) {
+  func foo() -> Int {
+    return 0
+  }
+
+  func foo(a: String) { // expected-error {{Invalid redeclaration of foo}}
+  }
+
+  func A() { // expected-error {{Invalid redeclaration of A}}
+  }
+
+  func bar() {
+    let a: Int = 0
+    let a: Int = 0 // expected-error {{Invalid redeclaration of a}}
+    let caller: Int = 0 // expected-error {{Invalid redeclaration of caller}}
+  }
+}
+
+struct A { // expected-error {{Invalid redeclaration of A}}
+}

--- a/Tests/SemanticTests/payable.flint
+++ b/Tests/SemanticTests/payable.flint
@@ -9,14 +9,14 @@ Payable :: (any) {
   }
 
   @payable
-  func foo(implicit parameter: Int) { // expected-error {{foo is declared @payable but doesn't have an implicit parameter of a currency type}}
+  func bar(implicit parameter: Int) { // expected-error {{bar is declared @payable but doesn't have an implicit parameter of a currency type}}
   }
 
   @payable
-  func foo(implicit parameter: Wei, implicit parameter2: Wei) { // expected-error {{Ambiguous implicit payable value parameter. Only one parameter can be declared implicit with a currency type}}
+  func baz(implicit parameter: Wei, implicit parameter2: Wei) { // expected-error {{Ambiguous implicit payable value parameter. Only one parameter can be declared implicit with a currency type}}
   }
 
   @payable
-  func foo(implicit parameter: Wei, implicit parameter2: Int) {
+  func qux(implicit parameter: Wei, implicit parameter2: Int) {
   }
 }


### PR DESCRIPTION
This resolves #183.

```swift
contract A {
  let x: Int = 0
  let x: Int = 2 // expected-error {{Invalid redeclaration of x}}
}

A :: caller <- (any) {
  func foo() -> Int {
    return 0
  }

  func foo(a: String) { // expected-error {{Invalid redeclaration of foo}}
  }

  func A() { // expected-error {{Invalid redeclaration of A}}
  }

  func bar() {
    let a: Int = 0
    let a: Int = 0 // expected-error {{Invalid redeclaration of a}}
    let caller: Int = 0 // expected-error {{Invalid redeclaration of caller}}
  }
}

struct A { // expected-error {{Invalid redeclaration of A}}
}
```