### PR TITLE
Fix function calls for inout parameters

### DIFF
--- a/Tests/BehaviorTests/tests/currency/currency.flint
+++ b/Tests/BehaviorTests/tests/currency/currency.flint
@@ -5,8 +5,12 @@ struct Coin {
     self.value = amount
   }
 
+  func getValue() -> Int {
+    return value
+  }
+
   mutating func transfer(other: inout Coin, amount: Int) {
-    if other.value >= amount {
+    if other.getValue() >= amount {
       value += amount
       other.value -= amount
     }


### PR DESCRIPTION
Calling a function on an `inout` parameter would generate bytecode which would always consider the parameter as being a memory address, which is incorrect as it could also have been a storage address.