### PR TITLE
Require contracts to have an explicit public initializer defined

### DIFF
--- a/Sources/IRGen/IULIAContract.swift
+++ b/Sources/IRGen/IULIAContract.swift
@@ -89,22 +89,10 @@ struct IULIAContract {
   }
 
   func renderPublicInitializer() -> String {
-    let initializerDeclaration: InitializerDeclaration
+    let (initializerDeclaration, contractBehaviorDeclaration) = findContractPublicInitializer()!
 
-    // The contract behavior declaration the initializer resides in.
-    let contractBehaviorDeclaration: ContractBehaviorDeclaration?
-
-    if let (publicInitializer, contractBehaviorDeclaration_) = findContractPublicInitializer() {
-      initializerDeclaration = publicInitializer
-      contractBehaviorDeclaration = contractBehaviorDeclaration_
-    } else {
-      // If there is not public initializer defined, synthesize one.
-      initializerDeclaration = synthesizeInitializer()
-      contractBehaviorDeclaration = nil
-    }
-
-    let capabilityBinding = contractBehaviorDeclaration?.capabilityBinding
-    let callerCapabilities = contractBehaviorDeclaration?.callerCapabilities ?? []
+    let capabilityBinding = contractBehaviorDeclaration.capabilityBinding
+    let callerCapabilities = contractBehaviorDeclaration.callerCapabilities
 
     let initializer = IULIAContractInitializer(initializerDeclaration: initializerDeclaration, typeIdentifier: contractDeclaration.identifier, propertiesInEnclosingType: contractDeclaration.variableDeclarations, capabilityBinding: capabilityBinding, callerCapabilities: callerCapabilities, environment: environment, isContractFunction: true).rendered()
 
@@ -125,12 +113,6 @@ struct IULIAContract {
       }
     }
     """
-  }
-
-  func synthesizeInitializer() -> InitializerDeclaration {
-    let sourceLocation = contractDeclaration.sourceLocation
-
-    return InitializerDeclaration(initToken: Token(kind: .init, sourceLocation: sourceLocation), attributes: [], modifiers: [Token(kind: .public, sourceLocation: sourceLocation)], parameters: [], closeBracketToken: Token(kind: .punctuation(.closeBracket), sourceLocation: sourceLocation), body: [], closeBraceToken: Token(kind: .punctuation(.closeBrace), sourceLocation: sourceLocation), scopeContext: ScopeContext(localVariables: []))
   }
 
   /// Finds the contract's public initializer, if any is declared, and returns the enclosing contract behavior declaration.

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer.swift
@@ -21,8 +21,13 @@ public struct SemanticAnalyzer: ASTPass {
 
   public func process(contractDeclaration: ContractDeclaration, passContext: ASTPassContext) -> ASTPassResult<ContractDeclaration> {
     var diagnostics = [Diagnostic]()
-    if let conflict = passContext.environment!.conflictingTypeDeclaration(for: contractDeclaration.identifier) {
+    let environment = passContext.environment!
+    if let conflict = environment.conflictingTypeDeclaration(for: contractDeclaration.identifier) {
       diagnostics.append(.invalidRedeclaration(contractDeclaration.identifier, originalSource: conflict))
+    }
+
+    if environment.publicInitializer(forContract: contractDeclaration.identifier.name) == nil {
+      diagnostics.append(.contractDoesNotHaveAPublicInitializer(contractIdentifier: contractDeclaration.identifier))
     }
     return ASTPassResult(element: contractDeclaration, diagnostics: diagnostics, passContext: passContext)
   }

--- a/Sources/SemanticAnalyzer/SemanticError.swift
+++ b/Sources/SemanticAnalyzer/SemanticError.swift
@@ -69,6 +69,10 @@ extension Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: initializerDeclaration.closeBraceToken.sourceLocation, message: "Return from initializer without initializing all properties", notes: notes)
   }
 
+  static func contractDoesNotHaveAPublicInitializer(contractIdentifier: Identifier) -> Diagnostic {
+    return Diagnostic(severity: .error, sourceLocation: contractIdentifier.sourceLocation, message: "Contract '\(contractIdentifier.name)' needs a public initializer accessible using the capability any")
+  }
+
   static func multiplePublicInitializersDefined(_ invalidAdditionalInitializer: InitializerDeclaration, originalInitializerLocation: SourceLocation) -> Diagnostic {
     let note = Diagnostic(severity: .note, sourceLocation: originalInitializerLocation, message: "A public initializer is already declared here")
     return Diagnostic(severity: .error, sourceLocation: invalidAdditionalInitializer.sourceLocation, message: "A public initializer has already been defined", notes: [note])

--- a/Tests/BehaviorTests/tests/array/array.flint
+++ b/Tests/BehaviorTests/tests/array/array.flint
@@ -7,6 +7,8 @@ contract Array {
 }
 
 Array :: (any) {
+  public init() {}
+  
   mutating func increaseNumWrites() {
     self.numWrites += 1 
   }

--- a/Tests/BehaviorTests/tests/currency/currency.flint
+++ b/Tests/BehaviorTests/tests/currency/currency.flint
@@ -22,6 +22,8 @@ contract C {
 }
 
 C :: (any) {
+  public init() {}
+
   public mutating func mint(index: Int, amount: Int) {
     accounts[index].value = amount
   }

--- a/Tests/BehaviorTests/tests/dictionary/dictionary.flint
+++ b/Tests/BehaviorTests/tests/dictionary/dictionary.flint
@@ -20,6 +20,8 @@ struct T {
 }
 
 Dictionary :: (any) {
+  public init() {}
+
   public mutating func write(addr: Address, value: Int) {
     storage[addr] = value
   }

--- a/Tests/BehaviorTests/tests/factorial/factorial.flint
+++ b/Tests/BehaviorTests/tests/factorial/factorial.flint
@@ -3,6 +3,8 @@ contract Factorial {
 }
 
 Factorial :: (any) {
+  public init() {}
+
   func factorial(n: Int) -> Int {
     if (n < 2) { return 1 } 
     return n * factorial(n - 1)

--- a/Tests/BehaviorTests/tests/memory/memory.flint
+++ b/Tests/BehaviorTests/tests/memory/memory.flint
@@ -4,6 +4,8 @@ contract C {
 }
 
 C :: (any) {
+  public init() {}
+
   public mutating func setS(a: Int, b: String) {
     let s: S = S(a, b)
     s.incrementA()

--- a/Tests/BehaviorTests/tests/operators/operators.flint
+++ b/Tests/BehaviorTests/tests/operators/operators.flint
@@ -1,6 +1,8 @@
 contract Operators {}
 
 Operators :: (any) {
+  public init() {}
+
   public func lessThan(a: Int, b: Int) -> Bool {
     return a < b
   }

--- a/Tests/ParserTests/capability_binding.flint
+++ b/Tests/ParserTests/capability_binding.flint
@@ -6,4 +6,9 @@ contract CapabilityBinding {}
 // CHECK-AST:   identifier "CapabilityBinding"
 // CHECK-AST:   capability binding "caller"
 // CHECK-AST:   identifier "any"
-CapabilityBinding :: caller <- (any) {}
+CapabilityBinding :: caller <- (any) {
+  
+// CHECK-AST: InitializerDeclaration
+// CHECK-AST:   public
+  public init() {}
+}

--- a/Tests/ParserTests/localvar.flint
+++ b/Tests/ParserTests/localvar.flint
@@ -5,6 +5,10 @@
 contract Foo {}
 
 Foo :: (any) {
+// CHECK-AST: InitializerDeclaration
+// CHECK-AST:   public
+  public init() {}
+  
   func foo() -> Int {
 
 // CHECK-AST: BinaryExpression

--- a/Tests/ParserTests/nested_branching.flint
+++ b/Tests/ParserTests/nested_branching.flint
@@ -3,6 +3,10 @@
 contract Branching {}
 
 Branching :: (any) {
+// CHECK-AST: InitializerDeclaration
+// CHECK-AST:   public
+  public init() {}
+  
   public func foo(a: Int) -> Int {
     if a > 6 {
       return 0

--- a/Tests/ParserTests/payable.flint
+++ b/Tests/ParserTests/payable.flint
@@ -3,6 +3,9 @@
 contract Payable {}
 
 Payable :: (any) {
+// CHECK-AST: InitializerDeclaration
+// CHECK-AST:   public
+  public init() {}
   
 // CHECK-AST: FunctionDeclaration
 // CHECK-AST: attribute payable

--- a/Tests/ParserTests/structs.flint
+++ b/Tests/ParserTests/structs.flint
@@ -7,6 +7,12 @@
 // CHECK-AST:     identifier "Test"
 contract Test {}
 
+Test :: (any) {
+// CHECK-AST: InitializerDeclaration
+// CHECK-AST:   public
+  public init() {}
+}
+
 // CHECK-AST: TopLevelDeclaration
 // CHECK-AST: StructDeclaration
 // CHECK-AST:   identifier "MyStruct"

--- a/Tests/ParserTests/types.flint
+++ b/Tests/ParserTests/types.flint
@@ -40,6 +40,9 @@ contract Foo {
 }
 
 Foo :: (any) {
+// CHECK-AST: InitializerDeclaration
+// CHECK-AST:   public
+  public init() {}
 
 // CHECK-AST: InitializerDeclaration
 // CHECK-AST: Parameter

--- a/Tests/SemanticTests/constants.flint
+++ b/Tests/SemanticTests/constants.flint
@@ -1,14 +1,16 @@
 // RUN: %flintc %s --verify
 
 contract Constants {
-  var a: Int // expected-error {{State property 'a' needs to be assigned a value}}
+  var a: Int // expected-note {{a is uninitialized}}
   var b: Int = "a" // expected-error {{Incompatible assignment between values of type Int and String}}
   let c: Int = 2 + 3
   let d: Int = 3
-  let e: Int // expected-error {{State property 'e' needs to be assigned a value}}
+  let e: Int // expected-note {{e is uninitialized}}
 }
 
 Constants :: (any) {
+  public init() {} // expected-error {{Return from initializer without initializing all properties}}
+
   mutating func foo() {
     let a: Int = 2 // expected-note {{'a' is declared here}}
     a = 3 // expected-error {{Cannot reassign to value: 'a' is a 'let' constant}}

--- a/Tests/SemanticTests/events.flint
+++ b/Tests/SemanticTests/events.flint
@@ -5,19 +5,18 @@ contract EventTest {
 }
 
 EventTest :: (any) {
-  func eventA(a: Int, b: Bool, c: Address) {
-  }
+  public init() {}
 
   func foo(c: Address) {
     eventA(3, true, c)
 
     eventA(true, false, c) // expected-error {{Cannot convert expression of type Bool to expected argument type Int}}
 
-    // expected-error@18 {{Cannot convert expression of type Bool to expected argument type Int}}
-    // expected-error@18 {{Cannot convert expression of type Int to expected argument type Bool}}
+    // expected-error@17 {{Cannot convert expression of type Bool to expected argument type Int}}
+    // expected-error@17 {{Cannot convert expression of type Int to expected argument type Bool}}
     eventA(true, 3, c) 
 
-// expected-error@21 {{Function eventA is not in scope or cannot be called using the caller capabilities (any)}}
+// expected-error@20 {{Function eventA is not in scope or cannot be called using the caller capabilities (any)}}
     eventA(true)
   }
 }

--- a/Tests/SemanticTests/invalid_redeclarations.flint
+++ b/Tests/SemanticTests/invalid_redeclarations.flint
@@ -6,6 +6,8 @@ contract A {
 }
 
 A :: caller <- (any) {
+  public init() {}
+
   func foo() -> Int {
     return 0
   }

--- a/Tests/SemanticTests/invalid_types.flint
+++ b/Tests/SemanticTests/invalid_types.flint
@@ -6,6 +6,8 @@ contract InvalidTypes {
 }
 
 InvalidTypes :: (any) {
+  public init() {}
+
   func foo() -> Bool {
     return int // expected-error {{Cannot convert expression of type Int to expected return type Bool}}
   }

--- a/Tests/SemanticTests/missing_init.flint
+++ b/Tests/SemanticTests/missing_init.flint
@@ -1,0 +1,3 @@
+// RUN: %flintc %s --verify
+
+contract Test {} // expected-error {{Contract 'Test' needs a public initializer accessible using the capability any}}

--- a/Tests/SemanticTests/mutating.flint
+++ b/Tests/SemanticTests/mutating.flint
@@ -7,6 +7,8 @@ contract Test {
 }
 
 Test :: (any) {
+  public init() {}
+
   func foo() -> Int {
     a[0] = 2 // expected-error {{Use of mutating statement in a nonmutating function}}
     return a[0]

--- a/Tests/SemanticTests/payable.flint
+++ b/Tests/SemanticTests/payable.flint
@@ -3,6 +3,7 @@
 contract Payable {}
 
 Payable :: (any) {
+  public init() {}
 
   @payable
   func foo() { // expected-error {{foo is declared @payable but doesn't have an implicit parameter of a currency type}}

--- a/Tests/SemanticTests/returns.flint
+++ b/Tests/SemanticTests/returns.flint
@@ -3,6 +3,8 @@
 contract Returns {}
 
 Returns :: (any) {
+  public init() {}
+
   func foo() -> Int {
     return 3
     var a: Int = 2 // expected-warning {{Code after return will never be executed}}

--- a/Tests/SemanticTests/structs.flint
+++ b/Tests/SemanticTests/structs.flint
@@ -23,7 +23,6 @@ contract Foo {
 }
 
 Foo :: (any) {
-
   public init() {
     a = Test()
     b = Test2()

--- a/Tests/SemanticTests/use_undeclared_identifier.flint
+++ b/Tests/SemanticTests/use_undeclared_identifier.flint
@@ -5,6 +5,8 @@ contract Test {
 }
 
 Test :: (any) {
+  public init() {}
+
   func foo() -> Int {
     var a: Int = b // expected-error {{Use of undeclared identifier b}}
     return 2


### PR DESCRIPTION
Contracts should have a public initializer defined, and it should be accessible using the 'any' capability.
Synthesizing public initializers can unexpectedly break clients of the contract.