### PR TITLE
Make diagnostic messages more consistent

### DIFF
--- a/Sources/Parser/Parser.swift
+++ b/Sources/Parser/Parser.swift
@@ -38,7 +38,7 @@ public class Parser {
       return (try parseTopLevelModule(), environment, [])
     } catch ParserError.expectedToken(let tokenKind, sourceLocation: let sourceLocation) {
       // A unhandled parsing error was thrown when parsing the program.
-      return (nil, environment, [Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected token \(tokenKind)")])
+      return (nil, environment, [Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected token '\(tokenKind)'")])
     } catch {
       // An invalid error was thrown.
       fatalError()

--- a/Sources/SemanticAnalyzer/TypeError.swift
+++ b/Sources/SemanticAnalyzer/TypeError.swift
@@ -9,14 +9,14 @@ import AST
 
 extension Diagnostic {
   static func incompatibleReturnType(actualType: Type.RawType, expectedType: Type.RawType, expression: Expression) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation, message: "Cannot convert expression of type \(actualType.name) to expected return type \(expectedType.name)")
+    return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation, message: "Cannot convert expression of type '\(actualType.name)' to expected return type '\(expectedType.name)'")
   }
 
   static func incompatibleAssignment(lhsType: Type.RawType, rhsType: Type.RawType, expression: Expression) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation, message: "Incompatible assignment between values of type \(lhsType.name) and \(rhsType.name)")
+    return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation, message: "Incompatible assignment between values of type '\(lhsType.name)' and '\(rhsType.name)'")
   }
 
   static func incompatibleArgumentType(actualType: Type.RawType, expectedType: Type.RawType, expression: Expression) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation, message: "Cannot convert expression of type \(actualType.name) to expected argument type \(expectedType.name)")
+    return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation, message: "Cannot convert expression of type '\(actualType.name)' to expected argument type '\(expectedType.name)'")
   }
 }

--- a/Tests/SemanticTests/constants.flint
+++ b/Tests/SemanticTests/constants.flint
@@ -1,11 +1,11 @@
 // RUN: %flintc %s --verify
 
 contract Constants {
-  var a: Int // expected-note {{a is uninitialized}}
-  var b: Int = "a" // expected-error {{Incompatible assignment between values of type Int and String}}
+  var a: Int // expected-note {{'a' is uninitialized}}
+  var b: Int = "a" // expected-error {{Incompatible assignment between values of type 'Int' and 'String'}}
   let c: Int = 2 + 3
   let d: Int = 3
-  let e: Int // expected-note {{e is uninitialized}}
+  let e: Int // expected-note {{'e' is uninitialized}}
 }
 
 Constants :: (any) {

--- a/Tests/SemanticTests/events.flint
+++ b/Tests/SemanticTests/events.flint
@@ -10,13 +10,13 @@ EventTest :: (any) {
   func foo(c: Address) {
     eventA(3, true, c)
 
-    eventA(true, false, c) // expected-error {{Cannot convert expression of type Bool to expected argument type Int}}
+    eventA(true, false, c) // expected-error {{Cannot convert expression of type 'Bool' to expected argument type 'Int'}}
 
-    // expected-error@17 {{Cannot convert expression of type Bool to expected argument type Int}}
-    // expected-error@17 {{Cannot convert expression of type Int to expected argument type Bool}}
+    // expected-error@17 {{Cannot convert expression of type 'Bool' to expected argument type 'Int'}}
+    // expected-error@17 {{Cannot convert expression of type 'Int' to expected argument type 'Bool'}}
     eventA(true, 3, c) 
 
-// expected-error@20 {{Function eventA is not in scope or cannot be called using the caller capabilities (any)}}
+// expected-error@20 {{Function 'eventA' is not in scope or cannot be called using the caller capability 'any'}}
     eventA(true)
   }
 }

--- a/Tests/SemanticTests/inits.flint
+++ b/Tests/SemanticTests/inits.flint
@@ -3,8 +3,8 @@
 contract Test {
   let a: Address
   var b: [Address] = []
-  var c: [Address: Int] = [] // expected-error {{Incompatible assignment between values of type [Address: Int] and [Any]}}
-  var d: [Int] = [:] // expected-error {{Incompatible assignment between values of type [Int] and [Any: Any]}}
+  var c: [Address: Int] = [] // expected-error {{Incompatible assignment between values of type '[Address: Int]' and '[Any]'}}
+  var d: [Int] = [:] // expected-error {{Incompatible assignment between values of type '[Int]' and '[Any: Any]'}}
   var e: Bool
   var f: Int
   let g: Bool
@@ -16,8 +16,8 @@ Test :: caller <- (any) {
     self.a = a
     self.f = f
   } // expected-error {{Return from initializer without initializing all properties}}
-  // expected-note@8 {{e is uninitialized}}
-  // expected-note@11 {{x is uninitialized}}
+  // expected-note@8 {{'e' is uninitialized}}
+  // expected-note@11 {{'x' is uninitialized}}
 
   public init() { // expected-error {{A public initializer has already been defined}}
     self.a = caller
@@ -37,12 +37,12 @@ Test :: caller <- (any) {
 
   mutating func foo() {
     x = B(1, true) 
-    x = C(1) // expected-error {{Incompatible assignment between values of type B and C}}
+    x = C(1) // expected-error {{Incompatible assignment between values of type 'B' and 'C'}}
   }
 }
 
 Test :: (a) {
-  public init(a: Address) { // expected-error {{Public contract initializer should be callable using caller capability "any"}}
+  public init(a: Address) { // expected-error {{Public contract initializer should be callable using caller capability 'any'}}
     self.a = a
     e = false
     f = 0
@@ -69,7 +69,7 @@ struct B {
 }
 
 struct C {
-  var a: Int // expected-note {{a is uninitialized}}
+  var a: Int // expected-note {{'a' is uninitialized}}
   let b: Bool = false
 
   init() {} // expected-error {{Return from initializer without initializing all properties}}

--- a/Tests/SemanticTests/invalid_function_call.flint
+++ b/Tests/SemanticTests/invalid_function_call.flint
@@ -11,7 +11,7 @@ Test :: caller <- (any) {
 
   public func foo() {
 
-// expected-error@15 {{Function bar is not in scope or cannot be called using the caller capabilities (any)}}
+// expected-error@15 {{Function 'bar' is not in scope or cannot be called using the caller capability 'any'}}
     bar()
   }
 }

--- a/Tests/SemanticTests/invalid_redeclarations.flint
+++ b/Tests/SemanticTests/invalid_redeclarations.flint
@@ -2,7 +2,7 @@
 
 contract A {
   let x: Int = 0
-  let x: Int = 2 // expected-error {{Invalid redeclaration of x}}
+  let x: Int = 2 // expected-error {{Invalid redeclaration of 'x'}}
 }
 
 A :: caller <- (any) {
@@ -12,18 +12,18 @@ A :: caller <- (any) {
     return 0
   }
 
-  func foo(a: String) { // expected-error {{Invalid redeclaration of foo}}
+  func foo(a: String) { // expected-error {{Invalid redeclaration of 'foo'}}
   }
 
-  func A() { // expected-error {{Invalid redeclaration of A}}
+  func A() { // expected-error {{Invalid redeclaration of 'A'}}
   }
 
   func bar() {
     let a: Int = 0
-    let a: Int = 0 // expected-error {{Invalid redeclaration of a}}
-    let caller: Int = 0 // expected-error {{Invalid redeclaration of caller}}
+    let a: Int = 0 // expected-error {{Invalid redeclaration of 'a'}}
+    let caller: Int = 0 // expected-error {{Invalid redeclaration of 'caller'}}
   }
 }
 
-struct A { // expected-error {{Invalid redeclaration of A}}
+struct A { // expected-error {{Invalid redeclaration of 'A'}}
 }

--- a/Tests/SemanticTests/invalid_types.flint
+++ b/Tests/SemanticTests/invalid_types.flint
@@ -9,20 +9,20 @@ InvalidTypes :: (any) {
   public init() {}
 
   func foo() -> Bool {
-    return int // expected-error {{Cannot convert expression of type Int to expected return type Bool}}
+    return int // expected-error {{Cannot convert expression of type 'Int' to expected return type 'Bool'}}
   }
 
   func bar() {
-    return 2 // expected-error {{Cannot convert expression of type Int to expected return type Void}}
+    return 2 // expected-error {{Cannot convert expression of type 'Int' to expected return type 'Void'}}
   }
 
   mutating func baz() {
     var a: Bool = true
-    a = b // expected-error {{Use of undeclared identifier b}}
+    a = b // expected-error {{Use of undeclared identifier 'b'}}
 
-    int = true // expected-error {{Incompatible assignment between values of type Int and Bool}}
+    int = true // expected-error {{Incompatible assignment between values of type 'Int' and 'Bool'}}
 
-    f(a) // expected-error {{Function f is not in scope or cannot be called using the caller capabilities (any)}}
+    f(a) // expected-error {{Function 'f' is not in scope or cannot be called using the caller capability 'any'}}
 
     f(self.int)
   }

--- a/Tests/SemanticTests/missing_init.flint
+++ b/Tests/SemanticTests/missing_init.flint
@@ -1,3 +1,3 @@
 // RUN: %flintc %s --verify
 
-contract Test {} // expected-error {{Contract 'Test' needs a public initializer accessible using the capability any}}
+contract Test {} // expected-error {{Contract 'Test' needs a public initializer accessible using the capability 'any'}}

--- a/Tests/SemanticTests/no_associated_contract.flint
+++ b/Tests/SemanticTests/no_associated_contract.flint
@@ -1,10 +1,10 @@
 // RUN: %flintc %s --verify
 
-// expected-error@4 {{Contract behavior declaration for Test has no associated contract declaration}}
+// expected-error@4 {{Contract behavior declaration for 'Test' has no associated contract declaration}}
 Test :: (any) { 
   func foo(a: Int) {
 
-    // expected-error@8 {{Cannot convert expression of type Int to expected return type Void}}
+    // expected-error@8 {{Cannot convert expression of type 'Int' to expected return type 'Void'}}
     return 3 * (1 + 2);
   }
 }

--- a/Tests/SemanticTests/payable.flint
+++ b/Tests/SemanticTests/payable.flint
@@ -6,11 +6,11 @@ Payable :: (any) {
   public init() {}
 
   @payable
-  func foo() { // expected-error {{foo is declared @payable but doesn't have an implicit parameter of a currency type}}
+  func foo() { // expected-error {{'foo' is declared @payable but doesn't have an implicit parameter of a currency type}}
   }
 
   @payable
-  func bar(implicit parameter: Int) { // expected-error {{bar is declared @payable but doesn't have an implicit parameter of a currency type}}
+  func bar(implicit parameter: Int) { // expected-error {{'bar' is declared @payable but doesn't have an implicit parameter of a currency type}}
   }
 
   @payable

--- a/Tests/SemanticTests/returns.flint
+++ b/Tests/SemanticTests/returns.flint
@@ -10,5 +10,5 @@ Returns :: (any) {
     var a: Int = 2 // expected-warning {{Code after return will never be executed}}
   }
 
-  func bar() -> Int {}  // expected-error {{Missing return in function expected to return Int}}
+  func bar() -> Int {}  // expected-error {{Missing return in function expected to return 'Int'}}
 }

--- a/Tests/SemanticTests/structs.flint
+++ b/Tests/SemanticTests/structs.flint
@@ -42,11 +42,11 @@ Foo :: (any) {
 
   mutating func a() {
     b(&a)
-    b(&b) // expected-error {{Function b is not in scope or cannot be called using the caller capabilities (any)}}
+    b(&b) // expected-error {{Function 'b' is not in scope or cannot be called using the caller capability 'any'}}
   }
 
   mutating func b(b: inout Test) {
     b(&b)
-    b(&self.b) // expected-error {{Function b is not in scope or cannot be called using the caller capabilities (any)}}
+    b(&self.b) // expected-error {{Function 'b' is not in scope or cannot be called using the caller capability 'any'}}
   }
 }

--- a/Tests/SemanticTests/undeclared_capability.flint
+++ b/Tests/SemanticTests/undeclared_capability.flint
@@ -10,7 +10,7 @@ Test :: caller <- (any) {
   }
 }
 
-Test :: (alice) { // expected-error {{Caller capability alice is undefined in Test or has incompatible type}}
+Test :: (alice) { // expected-error {{Caller capability 'alice' is undefined in 'Test' or has incompatible type}}
   func bar() {
   }
 }

--- a/Tests/SemanticTests/undeclared_identifiers.flint
+++ b/Tests/SemanticTests/undeclared_identifiers.flint
@@ -12,7 +12,7 @@ Test :: caller <- (any) {
   public func foo() {
     var a: Int = 0
     a += 1
-    b.foo() // expected-error {{Use of undeclared identifier b}}
-    // expected-error@15 {{Function foo is not in scope or cannot be called using the caller capabilities (any)}}
+    b.foo() // expected-error {{Use of undeclared identifier 'b'}}
+    // expected-error@15 {{Function 'foo' is not in scope or cannot be called using the caller capability 'any'}}
   }
 }

--- a/Tests/SemanticTests/use_undeclared_identifier.flint
+++ b/Tests/SemanticTests/use_undeclared_identifier.flint
@@ -8,7 +8,7 @@ Test :: (any) {
   public init() {}
 
   func foo() -> Int {
-    var a: Int = b // expected-error {{Use of undeclared identifier b}}
+    var a: Int = b // expected-error {{Use of undeclared identifier 'b'}}
     return 2
   }
 
@@ -16,7 +16,7 @@ Test :: (any) {
     if true {
       var a: Int = x
     } else {
-      a += 2 // expected-error {{Use of undeclared identifier a}}
+      a += 2 // expected-error {{Use of undeclared identifier 'a'}}
     }
   }
 }


### PR DESCRIPTION
This makes the diagnostic (errors/warnings) messages more consistent, e.g., all identifiers are put between apostrophes.