### PR TITLE
Error on local vars of array/dictionary type

### DIFF
--- a/Sources/IRGen/Function/IULIAExpression.swift
+++ b/Sources/IRGen/Function/IULIAExpression.swift
@@ -339,7 +339,11 @@ struct IULIASubscriptExpression {
 
     let environment = functionContext.environment
 
-    let offset = environment.propertyOffset(for: subscriptExpression.baseIdentifier.name, enclosingType: subscriptExpression.baseIdentifier.enclosingType!)!
+    guard let enclosingType = subscriptExpression.baseIdentifier.enclosingType,
+      let offset = environment.propertyOffset(for: subscriptExpression.baseIdentifier.name, enclosingType: enclosingType) else {
+      fatalError("Arrays and dictionaries cannot be defined as local variables yet.")
+    }
+
     let indexExpressionCode = IULIAExpression(expression: subscriptExpression.indexExpression).rendered(functionContext: functionContext)
 
     let type = environment.type(of: subscriptExpression.baseIdentifier.name, enclosingType: functionContext.enclosingTypeName)

--- a/Sources/SemanticAnalyzer/TypeChecker.swift
+++ b/Sources/SemanticAnalyzer/TypeChecker.swift
@@ -140,7 +140,7 @@ public struct TypeChecker: ASTPass {
       let lhsType = environment.type(of: binaryExpression.lhs, enclosingType: typeIdentifier.name, scopeContext: passContext.scopeContext!)
       let rhsType = environment.type(of: binaryExpression.rhs, enclosingType: typeIdentifier.name, scopeContext: passContext.scopeContext!)
 
-      if lhsType != rhsType, ![lhsType, rhsType].contains(.errorType) {
+      if !lhsType.isCompatible(with: rhsType), ![lhsType, rhsType].contains(.errorType) {
         diagnostics.append(.incompatibleAssignment(lhsType: lhsType, rhsType: rhsType, expression: .binaryExpression(binaryExpression)))
       }
     }


### PR DESCRIPTION
Local variables of array and dictionary types aren't supported yet, and this PR will throw a `fatalError` whenever any are encountered.