### PR TITLE
Support implicit self function calls in structs

### DIFF
--- a/Sources/IRGen/Function/IULIAExpression.swift
+++ b/Sources/IRGen/Function/IULIAExpression.swift
@@ -40,7 +40,7 @@ struct IULIAExpression {
       guard dictionaryLiteral.elements.count == 0 else { fatalError("Cannot render non-empty dictionary literals yet") }
       return "0"
     case .self(let `self`):
-      return IULIASelf(selfToken: self, asLValue: asLValue).rendered()
+      return IULIASelf(selfToken: self, asLValue: asLValue).rendered(functionContext: functionContext)
     case .subscriptExpression(let subscriptExpression):
       return IULIASubscriptExpression(subscriptExpression: subscriptExpression, asLValue: asLValue).rendered(functionContext: functionContext)
     case .sequence(let expressions):
@@ -228,7 +228,7 @@ struct IULIAFunctionCall {
         type = environment.type(of: argument, enclosingType: functionContext.enclosingTypeName, scopeContext: functionContext.scopeContext)
       }
       
-      return IULIAExpression(expression: argument, asLValue: type.isUserDefinedType).rendered(functionContext: functionContext)
+      return IULIAExpression(expression: argument, asLValue: false).rendered(functionContext: functionContext)
     }).joined(separator: ", ")
     return "\(functionCall.identifier.name)(\(args))"
   }
@@ -321,11 +321,12 @@ struct IULIASelf {
   var selfToken: Token
   var asLValue: Bool
   
-  func rendered() -> String {
+  func rendered(functionContext: FunctionContext) -> String {
     guard case .self = selfToken.kind else {
       fatalError("Unexpected token \(selfToken.kind)")
     }
-    return asLValue ? "0" : ""
+
+    return functionContext.isInStructFunction ? "_flintSelf" : asLValue ? "0" : ""
   }
 }
 

--- a/Tests/BehaviorTests/tests/structs/structs.flint
+++ b/Tests/BehaviorTests/tests/structs/structs.flint
@@ -9,6 +9,10 @@ struct A {
   mutating func setX(x: Int) {
     self.x = x
   }
+
+  func getY() -> Int {
+    return getX()
+  }
 }
 
 struct B {
@@ -17,6 +21,10 @@ struct B {
 
   func getXx() -> Int {
     return x.getX()
+  }
+
+  func getXx2() -> Int {
+    return x.getY()
   }
 
   mutating func setXx(y: Int) {
@@ -62,6 +70,10 @@ C :: (any) {
 
   public func getBxx2() -> Int {
     return b.getXx()
+  }
+
+  public func getBxx3() -> Int {
+    return b.getXx2()
   }
 
   public mutating func setBxx2(x: Int) {

--- a/Tests/BehaviorTests/tests/structs/test/test/test.js
+++ b/Tests/BehaviorTests/tests/structs/test/test/test.js
@@ -46,6 +46,9 @@ contract(config.contractName, function(accounts) {
 
     t = await instance.getBxx();
     assert.equal(t.valueOf(), 434);
+
+    t = await instance.getBxx2();
+    assert.equal(t.valueOf(), 434);
   });
 
   


### PR DESCRIPTION
```swift
struct S {
  func foo() -> Int {
    bar() // This didn't use to work
  }
  
  func bar() -> Int {
    return 2
  }
}
```