### PR TITLE
Support multiple input files

### DIFF
--- a/Sources/AST/SourceLocation.swift
+++ b/Sources/AST/SourceLocation.swift
@@ -5,22 +5,26 @@
 //  Created by Franklin Schrans on 1/7/18.
 //
 
+import Foundation
+
 /// A location in a source file.
 public struct SourceLocation: Equatable {
   public var line: Int
   public var column: Int
   public var length: Int
+  public var file: URL
 
-  public init(line: Int, column: Int, length: Int) {
+  public init(line: Int, column: Int, length: Int, file: URL) {
     self.line = line
     self.column = column
     self.length = length
+    self.file = file
   }
 
   public static func spanning<S1: SourceEntity, S2: SourceEntity>(_ lowerBoundEntity: S1, to upperBoundEntity: S2) -> SourceLocation {
     let lowerBound = lowerBoundEntity.sourceLocation
     let upperBound = upperBoundEntity.sourceLocation
     guard lowerBound.line == upperBound.line else { return lowerBound }
-    return SourceLocation(line: lowerBound.line, column: lowerBound.column, length: upperBound.column + upperBound.length - lowerBound.column)
+    return SourceLocation(line: lowerBound.line, column: lowerBound.column, length: upperBound.column + upperBound.length - lowerBound.column, file: lowerBound.file)
   }
 }

--- a/Sources/flintc/DiagnosticsFormatter.swift
+++ b/Sources/flintc/DiagnosticsFormatter.swift
@@ -19,9 +19,10 @@ public struct DiagnosticsFormatter {
   }
 
   func renderDiagnostic(_ diagnostic: Diagnostic, highlightColor: Color = .lightRed, style: Style = .bold) -> String {
+    let diagnosticFile = diagnostic.sourceLocation?.file
     var sourceFileText = ""
-    if let compilationContext = compilationContext {
-      sourceFileText = " in \(compilationContext.fileName.bold)"
+    if let file = diagnosticFile {
+      sourceFileText = " in \(file.path.bold)"
     }
 
     let infoTopic: String
@@ -35,10 +36,11 @@ public struct DiagnosticsFormatter {
     let infoLine = "\(infoTopic)\(sourceFileText):"
     let body: String
 
-    if let compilationContext = compilationContext {
+    if let compilationContext = compilationContext, let file = diagnosticFile {
+      let sourceCode = compilationContext.sourceCode(in: file)
       body = """
       \(diagnostic.message.indented(by: 2).bold)\(render(diagnostic.sourceLocation).bold):
-      \(renderSourcePreview(at: diagnostic.sourceLocation, sourceCode: compilationContext.sourceCode, highlightColor: highlightColor, style: style))
+      \(renderSourcePreview(at: diagnostic.sourceLocation, sourceCode: sourceCode, highlightColor: highlightColor, style: style))
       """
     } else {
       body = "  \(diagnostic.message.indented(by: 2).bold)"

--- a/Sources/flintc/StandardLibrary.swift
+++ b/Sources/flintc/StandardLibrary.swift
@@ -13,11 +13,9 @@ struct StandardLibrary {
   /// Path to the stdlib directory.
   var url: URL
 
-  func sourceCode() -> String {
-    let files = try! FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: nil, options: [])
+  var files: [URL] {
+    return try! FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: nil, options: [])
       .filter { $0.pathExtension == "flint" }
-
-    return try! files.map(String.init(contentsOf:)).joined(separator: "\n\n")
   }
 
   static var `default`: StandardLibrary {

--- a/Tests/BehaviorTests/compile_behavior_tests.sh
+++ b/Tests/BehaviorTests/compile_behavior_tests.sh
@@ -1,14 +1,16 @@
-#! /bin/sh
+#! /bin/bash
 
 for t in tests/*; do
   rm -rf $t/test/contracts
   mkdir $t/test/contracts
 
-  for f in $t/*.flint; do
-    [ -f "$f" ] || break
-    echo "Compile Flint file '$f'"
-    ../../.build/release/flintc $f --emit-ir --ir-output $t/test/contracts/
-  done
+  echo "Compile $t"
+  ../../.build/release/flintc $t/*.flint --emit-ir --ir-output $t/test/contracts/
+
+  #for f in $t/*.flint; do
+    #[ -f "$f" ] || break
+    #echo "Compile Flint file '$f'"
+  #done
 
   echo "pragma solidity ^0.4.2; contract Migrations {}" > $t/test/contracts/Migrations.sol
 done

--- a/Tests/BehaviorTests/tests/currency/Coin.flint
+++ b/Tests/BehaviorTests/tests/currency/Coin.flint
@@ -1,0 +1,25 @@
+struct Coin {
+  var value: Int
+
+  init(amount: Int) {
+    self.value = amount
+  }
+
+  init(other: inout Coin, amount: Int) {
+    if other.getValue() >= amount {
+      value += amount
+      other.value -= amount
+    }
+  }
+
+  func getValue() -> Int {
+    return value
+  }
+
+  mutating func transfer(other: inout Coin, amount: Int) {
+    if other.getValue() >= amount {
+      value += amount
+      other.value -= amount
+    }
+  }
+}

--- a/Tests/BehaviorTests/tests/currency/currency.flint
+++ b/Tests/BehaviorTests/tests/currency/currency.flint
@@ -1,29 +1,3 @@
-struct Coin {
-  var value: Int
-
-  init(amount: Int) {
-    self.value = amount
-  }
-
-  init(other: inout Coin, amount: Int) {
-    if other.getValue() >= amount {
-      value += amount
-      other.value -= amount
-    }
-  }
-
-  func getValue() -> Int {
-    return value
-  }
-
-  mutating func transfer(other: inout Coin, amount: Int) {
-    if other.getValue() >= amount {
-      value += amount
-      other.value -= amount
-    }
-  }
-}
-
 contract C {
   var accounts: [Int: Coin] = [:]
 }


### PR DESCRIPTION
Allow to compile multiple files together. This way, structs can be defined in separate files.

`flintc contract.flint s.flint`