### PR TITLE
Fix parsing of event declarations

### DIFF
--- a/Sources/Parser/Parser.swift
+++ b/Sources/Parser/Parser.swift
@@ -695,8 +695,11 @@ extension Parser {
     while let argumentEnd = indexOfFirstAtCurrentDepth([.punctuation(.comma), .punctuation(.closeBracket)]) {
       if let argument = try? parseExpression(upTo: argumentEnd) {
         let token = try consume(tokens[argumentEnd].kind)
-        if token.kind == .punctuation(.closeBracket) { closeBracketToken = token}
         arguments.append(argument)
+        if token.kind == .punctuation(.closeBracket) {
+          closeBracketToken = token
+          break
+        }
       } else {
         break
       }

--- a/Tests/ParserTests/types.flint
+++ b/Tests/ParserTests/types.flint
@@ -24,6 +24,14 @@ contract Foo {
   var value: Int = 0
 
 // CHECK-AST: VariableDeclaration
+// CHECK-AST:   identifier "s"
+// CHECK-AST:   user-defined type S
+// CHECK-AST:   FunctionCall
+// CHECK-AST:     identifier "S"
+// CHECK-AST:     literal 0
+  var s: S = S(0)
+
+// CHECK-AST: VariableDeclaration
 // CHECK-AST:   identifier "didCompleteSomething"
 // CHECK-AST:   built-in type Event
 // CHECK-AST:     Generic Arguments
@@ -51,4 +59,10 @@ Foo :: (any) {
   init(assignedValue: Int) {
     self.assignedValue = assignedValue
   }
+}
+
+// CHECK-AST: TopLevelDeclaration
+// CHECK-AST: StructDeclaration
+struct S {
+  init (a: Int) {}
 }


### PR DESCRIPTION
This fixes an issues where an event declaration wouldn't be parsed if the previous expression is a function call:

```swift
contract A {
  var s: S = S()
  var e: Event<Int> // this wouldn't be parsed
}
```