### PR TITLE
Add tabs to whitespace

### DIFF
--- a/Sources/Parser/Tokenizer.swift
+++ b/Sources/Parser/Tokenizer.swift
@@ -37,7 +37,7 @@ public struct Tokenizer {
 
     for (component, sourceLocation) in components {
       // Skip whitespace.
-      if component == " " {
+      if component.trimmingCharacters(in: CharacterSet.whitespaces).isEmpty {
         continue
       } else if let token = syntaxMap[component] {
         // The token is punctuation or a keyword.

--- a/Tests/ParserTests/whitespace.flint
+++ b/Tests/ParserTests/whitespace.flint
@@ -1,0 +1,49 @@
+// RUN: %flintc %s --dump-ast | %FileCheck %s --prefix CHECK-AST
+
+// CHECK-AST: TopLevelModule
+// CHECK-AST: TopLevelDeclaration
+// CHECK-AST: ContractDeclaration
+// CHECK-AST:   identifier "Test"
+contract Test {
+
+// CHECK-AST: VariableDeclaration
+// CHECK-AST:   identifier "owner"
+// CHECK-AST:   built-in type Address
+     var owner: Address
+
+// CHECK-AST: VariableDeclaration
+// CHECK-AST:   identifier "arr"
+// CHECK-AST:   FixedSizeArrayType
+// CHECK-AST:     built-in type Int
+// CHECK-AST:     size 4
+// CHECK-AST:   ArrayLiteral
+               var arr: Int[4] = []
+
+// CHECK-AST: VariableDeclaration
+// CHECK-AST:   identifier "arr2"
+// CHECK-AST:   ArrayType
+// CHECK-AST:     built-in type Int
+// CHECK-AST:   ArrayLiteral
+	var arr2: [Int] = []
+
+// CHECK-AST: VariableDeclaration
+// CHECK-AST:   identifier "numWrites"
+// CHECK-AST:   built-in type Int
+// CHECK-AST:   0
+		var numWrites: Int = 0
+}
+
+// CHECK-AST: TopLevelDeclaration
+// CHECK-AST: ContractBehaviorDeclaration
+// CHECK-AST:   identifier "Test"
+// CHECK-AST:   capability binding "caller"
+// CHECK-AST:   CallerCapability
+// CHECK-AST:     identifier "any"
+	Test :: caller <- (any) {
+  
+// CHECK-AST: InitializerDeclaration
+// CHECK-AST:   public
+  public init() {
+	  self.owner = caller
+  }
+}


### PR DESCRIPTION
This allows you to use tabs for indenting rather than just spaces.

While converting some Solidity Contracts to Flint @bearbin and I notices that tabs aren't included as whitespace.

